### PR TITLE
references: add AVD reference library site + Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,56 @@
+name: Deploy reference library
+
+# Builds the Jekyll site in references/ and publishes it to GitHub Pages.
+#
+# The site lives in references/ rather than docs/ so that docs/ stays free for
+# code documentation. GitHub Pages' "deploy from a branch" mode can only serve
+# / or /docs, so this workflow does the build instead. Set
+# Settings -> Pages -> Build and deployment -> Source to "GitHub Actions".
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'references/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Let a running deployment finish rather than cancelling it mid-publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./references
+          destination: ./_site
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/references/README.md
+++ b/references/README.md
@@ -1,0 +1,117 @@
+# AVD Reference Library — GitHub Pages site
+
+Source for the Air Vehicle Design reference library, published at
+<https://idopt-lab.github.io/air-vehicle-design/>.
+
+## How it is published
+
+The site is built by `.github/workflows/pages.yml` on every push to `main` that touches
+`references/**`. It is **not** served by Pages' "deploy from a branch" mode — that mode
+can only serve `/` or `/docs`, and `docs/` is reserved here for code documentation. The
+workflow runs the same `github-pages` Jekyll build, so `remote_theme` works exactly as it
+would natively.
+
+One-time repository setting:
+
+**Settings → Pages → Build and deployment → Source: GitHub Actions**
+
+No local Ruby or Jekyll install is needed.
+
+### baseurl
+
+This is a project site, so it serves under a subpath and `_config.yml` must carry:
+
+```yaml
+url: "https://idopt-lab.github.io"
+baseurl: "/air-vehicle-design"
+```
+
+Every internal link on the site is written as `{{ site.baseurl }}/page/`. If `baseurl` is
+emptied or the repository is renamed, all of them 404. There is no way to notice this
+locally without a full Jekyll build, so treat it as load-bearing.
+
+### Editing workflow
+
+Work on the long-lived `references` branch, then merge to `main` to publish:
+
+```bash
+git checkout references
+# ...edit under references/...
+git commit -am "references: ..."
+git push
+# open a PR, merge to main -> the workflow publishes
+git checkout references && git merge main    # fast-forward so the branch doesn't drift
+```
+
+Merging is what publishes. Pushing to the `references` branch alone changes nothing on
+the live site.
+
+## Theme
+
+Uses [just-the-docs](https://just-the-docs.com/) via `remote_theme`, which GitHub Pages
+supports natively. It provides the left sidebar navigation and full-text search with no
+build configuration.
+
+To preview locally (optional):
+
+```bash
+gem install bundler jekyll
+bundle init
+bundle add jekyll github-pages webrick
+bundle exec jekyll serve
+```
+
+## File layout
+
+| File | Page |
+|------|------|
+| `index.md` | Start Here — ID scheme, availability tags, page index |
+| `course-modules.md` | Course Modules — Raj's 22 decks, syllabi, reference crosswalk |
+| `foundations.md` | Foundations & Design Process |
+| `requirements-conops.md` | Requirements & Concept of Operations |
+| `aerodynamics.md` | Aerodynamics |
+| `configuration-fuselage.md` | Configuration & Fuselage |
+| `propulsion-performance.md` | Propulsion & Performance |
+| `stability-control.md` | Stability & Control |
+| `structures-weights.md` | Structures & Weights |
+| `cost.md` | Cost & Value |
+| `survivability-stealth.md` | Survivability & Stealth |
+| `subsystems-avionics.md` | Subsystems & Avionics |
+| `operations-environment.md` | Operations, Market & Environment |
+| `electrified-aircraft.md` | Electrified Aircraft |
+| `case-studies.md` | Mission Case Studies |
+| `project-management-ethics.md` | Project Management & Ethics |
+| `industry-news.md` | Industry News & Current Events |
+
+## Adding a reference
+
+Follow the existing pattern. Within a topic, under `### Primary References` or
+`### Secondary References`:
+
+```markdown
+1. **CAT-TOP-P01** — [Title](https://url)
+   Author, A. B., "Full Title," *Publication*, Vol., No., Year, pp. doi:...
+   One or two sentences on what it is and when to use it.
+   `Open`
+```
+
+Availability tag is one of `Open`, `Publisher`, or `Citation only`.
+Category codes are listed on the Start Here page. Keep IDs stable once published —
+students will be citing them.
+
+An optional `VT access: [...](url)` line goes immediately above the tag, for entries that
+Virginia Tech subscribes to through Knovel, Wiley, ScienceDirect or ProQuest. These come
+from Prof. Raj's *List of Primary References* (August 2024) with search-session query
+strings stripped. The public link stays the main one — the VT link is an extra, because
+the site is meant to work for readers outside VT too.
+
+If you add or renumber an entry that appears in Prof. Raj's list, update the crosswalk
+table at the bottom of `course-modules.md` — it is what lets students follow a citation
+from his slides into this library.
+
+## Link maintenance
+
+All external links were verified when the site was built. A few hosts
+(DTIC, ScienceDirect, AIAA ARC, Medium, Aviation Week) block automated checkers but work
+normally in a browser. If you add an automated link checker to CI, allowlist those hosts
+to avoid false failures.

--- a/references/_config.yml
+++ b/references/_config.yml
@@ -1,0 +1,50 @@
+title: AVD Reference Library
+description: Curated reference library for Air Vehicle Design
+remote_theme: just-the-docs/just-the-docs
+
+# Served from https://idopt-lab.github.io/air-vehicle-design/
+# baseurl MUST match the repo name — every internal link on the site is built
+# from {{ site.baseurl }}, so an empty value 404s all of them.
+url: "https://idopt-lab.github.io"
+baseurl: "/air-vehicle-design"
+
+# Sidebar / navigation
+nav_sort: case_insensitive
+heading_anchors: true
+
+# Search
+search_enabled: true
+search:
+  heading_level: 3
+  previews: 3
+  preview_words_before: 5
+  preview_words_after: 10
+  tokenizer_separator: /[\s/]+/
+  rel_url: true
+  button: false
+
+# Footer
+back_to_top: true
+back_to_top_text: "Back to top"
+last_edit_timestamp: false
+
+color_scheme: light
+
+aux_links:
+  "Kevin T. Crofton Dept. of Aerospace & Ocean Engineering":
+    - "https://www.aoe.vt.edu/"
+aux_links_new_tab: true
+
+# Open external links in a new tab
+callouts:
+  note:
+    title: Note
+    color: blue
+  warning:
+    title: Heads up
+    color: yellow
+
+exclude:
+  - README.md
+  - Gemfile
+  - Gemfile.lock

--- a/references/aerodynamics.md
+++ b/references/aerodynamics.md
@@ -1,0 +1,153 @@
+---
+layout: default
+title: Aerodynamics
+nav_order: 5
+permalink: /aerodynamics/
+---
+
+# Aerodynamics
+{: .no_toc }
+
+Drag estimation and high-speed wing design at the level of fidelity a conceptual design
+actually supports.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Induced Drag & Oswald Factor (OSW)
+
+### Primary References
+
+1. **AER-OSW-P01** — [Estimating the Oswald Factor from Basic Aircraft Geometrical Parameters](https://www.fzt.haw-hamburg.de/pers/Scholz/OPerA/OPerA_PUB_DLRK_12-09-10.pdf)
+   Niţă, M., and Scholz, D., "Estimating the Oswald Factor from Basic Aircraft Geometrical
+   Parameters," *Deutscher Luft- und Raumfahrtkongress 2012*, Berlin, 10–12 September 2012.
+   Document ID 281424. 19 pp.
+   **Use this instead of assuming _e_ = 0.8.** Builds a theoretical Oswald factor from taper
+   ratio and sweep, then corrects for fuselage, zero-lift drag and Mach number using
+   statistical aircraft data. Claimed accuracy within 4%. Also covers non-planar
+   configurations — winglets, dihedral and box wings.
+   `Open`
+
+### Secondary References
+
+1. **AER-OSW-S01** — [DGLR publication record, Document ID 281424](https://publikationen.dglr.de/?tx_dglrpublications_pi1%5Bdocument_id%5D=281424)
+   Official conference record for AER-OSW-P01, with the persistent URN
+   `urn:nbn:de:101:1-201212176728`. Cite this if you need a formal archival reference.
+   `Open`
+
+---
+
+## Topic: Transonic Aerodynamics (TRN)
+
+### Primary References
+
+1. **AER-TRN-P01** — [Transonic Aerodynamics of Airfoils and Wings](https://archive.aoe.vt.edu/mason/Mason_f/ConfigAeroTransonics.pdf)
+   Mason, W. H., "Transonic Aerodynamics of Airfoils and Wings," Ch. 7 in
+   *Configuration Aerodynamics*, Virginia Tech, 2006. 24 pp.
+   Why transonic cruise is hard, what supercritical airfoils actually buy you, and how to
+   pick a drag-divergence Mach number. Defines M<sub>DD</sub> at dC<sub>D</sub>/dM = 0.10 —
+   use that definition consistently in your drag rise model.
+   Now also published as a chapter of the VT open textbook
+   [Lecture Notes on Configuration Aerodynamics](https://pressbooks.lib.vt.edu/configurationaerodynamics/).
+   `Open`
+
+### Secondary References
+
+1. **AER-TRN-S01** — [Subsonic Aerodynamics of Airfoils and Wings](https://archive.aoe.vt.edu/mason/Mason_f/ConfigAeroSubFoilWing.pdf)
+   Mason, W. H., "Subsonic Aerodynamics of Airfoils and Wings," Ch. 6 in
+   *Configuration Aerodynamics*, Virginia Tech, 2006.
+   The companion chapter to AER-TRN-P01. Read first if your cruise Mach is below drag rise.
+   `Open`
+
+---
+
+## Topic: Supersonic Wing Design (SUP)
+
+### Secondary References
+
+1. **AER-SUP-S01** — [Aerodynamic shape optimization of a supersonic transport including a subsonic static margin constraint](https://doi.org/10.1016/j.ast.2025.110565)
+   Seraj, S., Yildirim, A., and Martins, J. R. R. A., "Aerodynamic shape optimization of a
+   supersonic transport including a subsonic static margin constraint,"
+   *Aerospace Science and Technology*, Vol. 166, 2025, Art. 110565.
+   doi:10.1016/j.ast.2025.110565
+   RANS-based shape optimization of a three-surface supersonic transport. The point for a
+   design course is the coupling: optimizing purely for supersonic cruise drives the
+   configuration into an unacceptable low-speed stability condition, so the static margin
+   has to enter the optimization as a constraint. Directly relevant to any supersonic
+   project. See also [Mission Case Studies]({{ site.baseurl }}/case-studies/).
+   `Publisher`
+
+---
+
+## Topic: Aerodynamics Texts & Airfoil Data (TXT)
+
+### Primary References
+
+1. **AER-TXT-P01** — [Theory of Wing Sections, Including a Summary of Airfoil Data](https://store.doverpublications.com/products/9780486605869)
+   Abbott, I. H., and von Doenhoff, A. E., *Theory of Wing Sections, Including a Summary of
+   Airfoil Data*, Dover Publications, New York, 1959. ISBN 978-0-486-60586-9.
+   The airfoil data source. You need it for section lift curve slope, c<sub>l,max</sub>,
+   moment coefficient and drag bucket when you pick an airfoil — the appendix is the reason
+   the book is still in print. In print from Dover; borrowable scan at the
+   [Internet Archive](https://archive.org/details/theoryofwingsect0000abbo).
+   Much of the same data is free in the underlying NACA report, cited as AER-TXT-S04.
+   `Publisher`
+
+2. **AER-TXT-P02** — [Introduction to Transonic Aerodynamics](https://doi.org/10.1007/978-94-017-9747-4)
+   Vos, R., and Farokhi, S., *Introduction to Transonic Aerodynamics*, Fluid Mechanics and
+   Its Applications, Vol. 110, Springer, Dordrecht, 2015. doi:10.1007/978-94-017-9747-4
+   Book-length treatment of the regime every transport design sits in. Where Mason's chapter
+   (AER-TRN-P01) gives you the design rules, this gives you the physics they come from —
+   shock/boundary-layer interaction, supercritical section design, and sweep theory with its
+   limits.
+   `Publisher`
+
+3. **AER-TXT-P03** — [Lecture Notes on Configuration Aerodynamics](https://pressbooks.lib.vt.edu/configurationaerodynamics/)
+   Mason, W. H., *Lecture Notes on Configuration Aerodynamics*, Virginia Tech Open
+   Textbook, University Libraries, Virginia Tech.
+   Bill Mason's Virginia Tech notes, released as an open textbook. Aerodynamics written for
+   the configuration designer rather than the aerodynamicist — the whole book is about what
+   the shape does to the numbers. It is the parent text of AER-TRN-P01 and AER-TRN-S01
+   above, and its RCS chapter is cited on the
+   [Survivability & Stealth]({{ site.baseurl }}/survivability-stealth/) page. Free, current,
+   and written for this department.
+   `Open`
+
+### Secondary References
+
+1. **AER-TXT-S01** — [Aerodynamics for Engineers](https://doi.org/10.1017/9781009105842)
+   Bertin, J. J., and Cummings, R. M., *Aerodynamics for Engineers*, 6th ed., Cambridge
+   University Press, Cambridge, 2021. doi:10.1017/9781009105842
+   The undergraduate aerodynamics text, included here as the fallback when a method on this
+   page assumes something you have forgotten. Raj's list cites the earlier Prentice-Hall
+   editions.
+   `Publisher`
+
+2. **AER-TXT-S02** — [Aircraft Aerodynamic Design with Computational Software](https://doi.org/10.1017/9781139094672)
+   Rizzi, A., and Oppelstrup, J., *Aircraft Aerodynamic Design with Computational Software*,
+   Cambridge University Press, Cambridge, 2021. doi:10.1017/9781139094672
+   Aerodynamic design done through actual computational tools, with the software and
+   exercises supplied. The right reference if your project goes past handbook methods into
+   panel or CFD work — it is explicit about what each level of fidelity can and cannot
+   settle.
+   `Publisher`
+
+3. **AER-TXT-S03** — [The Aerodynamic Design of Aircraft](https://doi.org/10.2514/4.869228)
+   Küchemann, D., *The Aerodynamic Design of Aircraft*, AIAA Education Series, AIAA, Reston,
+   VA, 2012 (reprint of Pergamon Press, Oxford, 1978). doi:10.2514/4.869228
+   Küchemann's classification of aircraft by the flow type they exploit — classical, swept,
+   slender, waverider — and the design consequences of each. The deepest statement available
+   of *why* configurations look the way they do at a given Mach number. Hard going, but the
+   framework is worth having before you choose a planform.
+   VT access: [Knovel (VT sign-in)](https://app-knovel-com.ezproxy.lib.vt.edu/web/toc.v/cid:kpADA0000T/viewerType:toc//root_slug:aerodynamic-design-aircraft)
+   `Publisher`
+
+4. **AER-TXT-S04** — [Summary of Airfoil Data](https://ntrs.nasa.gov/api/citations/19930090976/downloads/19930090976.pdf)
+   Abbott, I. H., von Doenhoff, A. E., and Stivers, L. S., Jr., *Summary of Airfoil Data*,
+   NACA Report No. 824, National Advisory Committee for Aeronautics, 1945.
+   NTRS citation: [19930090976](https://ntrs.nasa.gov/citations/19930090976)
+   The NACA report that became the data appendix of AER-TXT-P01 — section characteristics
+   for the 4-, 5- and 6-series airfoils, free. Use this if you cannot get the book.
+   `Open`

--- a/references/case-studies.md
+++ b/references/case-studies.md
@@ -1,0 +1,321 @@
+---
+layout: default
+title: Mission Case Studies
+nav_order: 15
+permalink: /case-studies/
+---
+
+# Mission Case Studies
+{: .no_toc }
+
+Complete designs, organized by mission. Use these two ways: as domain background when your
+project falls into one of these mission areas, and as worked examples of how a design study
+is scoped, executed and written up.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Carrier Strike Fighter (CSF)
+
+### Primary References
+
+1. **CAS-CSF-P01** — [Review of the Carrier Approach Criteria for Carrier-Based Aircraft, Phase I](https://apps.dtic.mil/sti/citations/ADA411068)
+   Rudowsky, T., Hynes, M., Luter, M., Niewoehner, R., Senn, P., et al.,
+   NAWCADPAX/TR-2002/71, Naval Air Warfare Center Aircraft Division, Patuxent River, MD,
+   10 October 2002. 219 pp. DTIC ADA411068.
+   Historical review, requirements analysis, and assessment of legacy aircraft against the
+   carrier approach speed criteria. The single most useful open document for a
+   carrier-based design. Approved for public release.
+   Direct PDF: [apps.dtic.mil/sti/tr/pdf/ADA411068.pdf](https://apps.dtic.mil/sti/tr/pdf/ADA411068.pdf)
+   `Open`
+
+2. **CAS-CSF-P02** — [The Influence of Ship Configuration on the Design of the Joint Strike Fighter](https://apps.dtic.mil/sti/citations/ADA399988)
+   Ryberg, E. S., Engineering the Total Ship (ETS) 2002 Symposium, Gaithersburg, MD,
+   26–27 February 2002. Joint Strike Fighter Program Office. 12 pp. DTIC ADA399988.
+   How US carrier and amphibious assault ship geometry, and the UK INVINCIBLE class,
+   constrained the CV and STOVL JSF variants. Read for the ship-air interface constraints
+   that a landbased design never sees.
+   Direct PDF: [apps.dtic.mil/sti/pdfs/ADA399988.pdf](https://apps.dtic.mil/sti/pdfs/ADA399988.pdf)
+   `Open`
+
+3. **CAS-CSF-P03** — NAVAIR 00-80T-105, CV NATOPS Manual
+   Commander, Naval Air Forces, *CV NATOPS Manual*, NAVAIR 00-80T-105, 15 August 2025.
+   228 pp.
+   Carrier flight deck operating procedures — the operational reality your design has to fit
+   into. **Controlled Unclassified Information; Distribution Statement C.** Not publicly
+   releasable, and not obtainable through open channels. Use CAS-CSF-P01 and P02 for the
+   design-relevant constraints instead.
+   `Citation only`
+
+4. **CAS-CSF-P04** — A1-F18EA-NFM-200, NATOPS Flight Manual Performance Data, F/A-18E/F
+   Naval Air Systems Command, *NATOPS Flight Manual Performance Data, Navy Model F/A-18E/F,
+   165533 and Up Aircraft*, A1-F18EA-NFM-200, 1 July 2002, Change 3, 1 August 2006. 408 pp.
+   Full performance charts for the aircraft the strike fighter RFP is replacing — the
+   natural baseline for comparison. **Distribution Statement C.** Not publicly releasable.
+   `Citation only`
+
+### Secondary References
+
+1. **CAS-CSF-S01** — F/A-36 Stingray: A Response to NAVAIR's 2013 Tactical Fighter Request for Proposal
+   Hokie Works (Team 6), *F/A-36 Stingray*, undergraduate aircraft design final report,
+   Virginia Polytechnic Institute and State University, 7 May 2014. 76 pp.
+   A previous Virginia Tech team's complete response to the carrier strike fighter RFP.
+   The most directly comparable example of the deliverable you are producing. Distributed
+   through the course; no public copy located.
+   For other VT design reports see the
+   [Virginia Tech Aircraft Design Reports archive](https://archive.aoe.vt.edu/mason/Mason_f/SD1SrDesRpts.html).
+   `Citation only`
+
+2. **CAS-CSF-S02** — [YF-23 Designer Offers His Take On Boeing's F-47 NGAD Configuration](https://aviationweek.com/defense/aircraft-propulsion/yf-23-designer-offers-his-take-boeings-f-47-ngad-configuration)
+   Warwick, G., *Aviation Week & Space Technology*, 11 April 2025.
+   Darold Cummings — chief configuration designer for the Northrop YF-23 — reverse-engineers
+   the F-47 configuration from two heavily doctored released images. An unusually good
+   demonstration of reading a configuration: what the visible geometry implies about
+   mission, internal volume and signature priorities. Subscription required.
+   `Publisher`
+
+3. **CAS-CSF-S03** — [YF-23 Designer Weighs In On How Lockheed Martin Could Evolve The F-35](https://aviationweek.com/aerospace/aircraft-propulsion/yf-23-designer-weighs-how-lockheed-martin-could-evolve-f-35)
+   Warwick, G., *Aviation Week & Space Technology*, 7 August 2025.
+   Three evolved F-35 concepts by Cummings. A worked example of derivative design under
+   constraint — how much capability can be added to an existing airframe, and at what point
+   a clean sheet becomes the better answer. Subscription required.
+   `Publisher`
+
+---
+
+## Topic: Aerial Firefighting (FIR)
+
+### Primary References
+
+1. **CAS-FIR-P01** — [Conceptual Design of Uninhabited Aircraft for Support of Wildfire Suppression](https://ntrs.nasa.gov/api/citations/20260000623/downloads/tvf2026_WildfireSuppression.pdf)
+   Silva, C. (NASA Ames), and Solis, E. (Analytical Mechanics Associates), *VFS Vertical
+   Lift Aircraft Design & Aeromechanics Specialists' Conference*, San Jose, CA,
+   27–29 January 2026. 9 pp. NTRS: [20260000623](https://ntrs.nasa.gov/citations/20260000623)
+   A complete small-UAS conceptual design done properly: requirements development,
+   constraint identification, tool selection (NDARC), and results. Four-rotor vehicle
+   delivering 20+ kg to a point 10 nm away through 30 kt winds, transportable in a
+   medium-duty pickup. **The clearest short example of a full design process in this
+   library.** US Government work, not subject to copyright.
+   `Open`
+
+2. **CAS-FIR-P02** — [Help is on the Way: Opportunities and Challenges of Novel Rotorcraft and Associated Systems for Disaster Relief and Emergency Response](https://ntrs.nasa.gov/api/citations/20260000515/downloads/DRER_Fliers_Vision_Paper.pdf)
+   Young, L., Kallstrom, K., Conley, S., and Shirazi, D. (NASA Ames), *VFS Vertical Lift
+   Aircraft Design & Aeromechanics Specialists' Conference*, San Jose, CA,
+   27–29 January 2026. 18 pp. NTRS: [20260000515](https://ntrs.nasa.gov/citations/20260000515)
+   Broad survey of the disaster relief and emergency response mission space and the vehicle
+   concepts that could serve it. Good source of mission requirements if your project targets
+   this domain.
+   `Open`
+
+### Secondary References
+
+1. **CAS-FIR-S01** — [Applications and Assessments of Uncrewed Aerial Vehicles for Dual-Use Public Good and Military Missions](https://ntrs.nasa.gov/api/citations/20260000574/downloads/TVF26_Dual_Use.pdf)
+   Scott, R., and Conley, S. (NASA Ames), *VFS Vertical Lift Aircraft Design &
+   Aeromechanics Specialists' Conference*, San Jose, CA, 27–29 January 2026. 13 pp.
+   NTRS: [20260000574](https://ntrs.nasa.gov/citations/20260000574)
+   Design considerations for vehicles serving both civil and military roles, and the
+   logistics of a reserve fleet for disaster response. Relevant to any dual-use requirement.
+   `Open`
+
+2. **CAS-FIR-S02** — [Sensitivity analysis of aerial wildfire fighting tactics with heterogeneous fleets using an agent-based simulation framework](https://doi.org/10.1007/s13272-025-00840-3)
+   Cigal, N., et al. (DLR), *CEAS Aeronautical Journal*, 2025.
+   doi:10.1007/s13272-025-00840-3. 31 pp.
+   System-of-systems view: response time, fleet composition and tactics, evaluated by
+   agent-based simulation. Shows why single-aircraft optimization is the wrong objective
+   when the aircraft operates as part of a fleet.
+   Also at [DLR elib](https://elib.dlr.de/196143/).
+   `Publisher`
+
+3. **CAS-FIR-S03** — [Leveraging High-Fidelity Digital Models and Reinforcement Learning for Mission Engineering: A Case Study of Aerial Firefighting Under Perfect Information](https://arxiv.org/abs/2512.20589)
+   Çetinkaya, İ. O., Khodadadian, S., and Topcu, T. G. (Grado Dept. of Industrial and
+   Systems Engineering, Virginia Tech), *23rd Annual Conference on Systems Engineering
+   Research (CSER)*, Arlington, VA, 6–9 April 2026. arXiv:2512.20589. 12 pp.
+   Mission engineering with a reinforcement learning coordinator over a high-fidelity
+   digital mission model. Virginia Tech work. **Open access preprint.**
+   Direct PDF: [arxiv.org/pdf/2512.20589](https://arxiv.org/pdf/2512.20589)
+   `Open`
+
+4. **CAS-FIR-S04** — [A Hierarchical Agent-Based Model for Decision Making Under Uncertainty in Tactical Firefighting](https://doi.org/10.2514/6.2026-0561)
+   Abyad, M. O., Bagdatli, B., and Mavris, D. N. (Aerospace Systems Design Laboratory,
+   Georgia Tech), AIAA Paper 2026-0561, *AIAA SciTech Forum*, Orlando, FL,
+   12–16 January 2026. 19 pp. doi:10.2514/6.2026-0561
+   Agent-based modelling combined with Monte Carlo Tree Search for deploying ground and
+   aerial assets under uncertainty.
+   `Publisher`
+
+5. **CAS-FIR-S05** — Applying Optimization Methods to Wildfire: A Simulation Study
+   Evans, J. W., Bagdatli, B., and Mavris, D. N. (Aerospace Systems Design Laboratory,
+   Georgia Tech), AIAA SciTech Forum, 2026. 17 pp.
+   Compares cost functions for retardant drop placement and optimizes with brute force,
+   Bayesian optimization and differential evolution. No public copy located; see the
+   [ASDL publications list](https://www.asdl.gatech.edu/research/publications/).
+   `Citation only`
+
+6. **CAS-FIR-S06** — [10 Tanker Air Carrier — DC-10 Very Large Air Tanker](https://www.10tanker.com/aboutus)
+   10 Tanker Air Carrier, DC-10-30 VLAT fact sheet.
+   Reference data for the existing very large air tanker fleet: 9,400 US gal retardant
+   capacity released in eight seconds, four aircraft in service (Tankers 910, 911, 912, 914).
+   Useful as the incumbent baseline for a firefighting design.
+   `Open`
+
+---
+
+## Topic: Urban & Advanced Air Mobility (UAM)
+
+### Primary References
+
+1. **CAS-UAM-P01** — [Impact of Technology and Mission Variations on Aircraft Designed for Advanced Air Mobility](https://rotorcraft.arc.nasa.gov/Publications/files/TVF2026_JohnsonSilva.pdf)
+   Johnson, W., and Silva, C. (NASA Ames), *VFS Vertical Lift Aircraft Design &
+   Aeromechanics Specialists' Conference*, San Jose, CA, 27–29 January 2026. 14 pp.
+   Technology and mission sensitivity study across the NASA AAM concept vehicles —
+   quadrotor, quiet single main rotor, side-by-side and tiltrotor, each in turboshaft and
+   electric variants. **The reference set of AAM baseline designs.** Read for the
+   sensitivity results: which technology assumptions actually move the sized vehicle.
+   Also at [NTRS](https://ntrs.nasa.gov/api/citations/20250006187/downloads/Johnson%20NASA-TP20250006187.pdf).
+   `Open`
+
+2. **CAS-UAM-P02** — [Concept of Operations for Automated Flight Rules](https://cdn.bfldr.com/3FMO7QHS/as/3j55gvks8t92r5fv7jm2f5b/Wisk_Boeing_and_SkyGrid_ConOps)
+   Boeing, Wisk Aero, and SkyGrid, December 2025. 32 pp.
+   See [Requirements & ConOps]({{ site.baseurl }}/requirements-conops/) for the full entry.
+   `Open`
+
+### Secondary References
+
+1. **CAS-UAM-S01** — [Enabling Scalable Urban Air Mobility Through Automated Flight Rules](https://www.skygrid.com/wp-content/uploads/2026/02/Enabling-Scalable-Urban-Air-Mobility-Through-Automated-Flight-Rules-White-Paper.pdf)
+   SkyGrid, LLC, and Wisk Aero, white paper, February 2026. 30 pp.
+   `Open`
+
+2. **CAS-UAM-S02** — [Preliminary Sizing of an eVTOL Lift-Cruise Aircraft](https://doi.org/10.21203/rs.3.rs-4099036/v1)
+   Heidary, M., and Kosari, A., Research Square preprint, 2024.
+   See [Electrified Aircraft]({{ site.baseurl }}/electrified-aircraft/).
+   `Open`
+
+3. **CAS-UAM-S03** — [eVTOL Performance Analysis: A Review From Control Perspectives](https://ieeexplore.ieee.org/document/10496812/)
+   Su, J., et al., *IEEE Transactions on Intelligent Vehicles*, 2024.
+   See [Electrified Aircraft]({{ site.baseurl }}/electrified-aircraft/).
+   `Publisher`
+
+4. **CAS-UAM-S04** — Design of a Manned eVTOL Aircraft using Cycloidal Rotors
+   Fardin, N. (Oklahoma State University), Brown, C. (Texas A&M University),
+   Benedict, M. (Texas A&M University), and Halder, A. (Oklahoma State University),
+   Vertical Flight Society. 18 pp.
+   Design of a 2,000 lb manned eVTOL using cycloidal rotor propulsion. Worth reading as an
+   example of sizing around a genuinely unconventional propulsor. No public copy located.
+   `Citation only`
+
+---
+
+## Topic: Supersonic Transport (SST)
+
+### Primary References
+
+1. **CAS-SST-P01** — [Aerodynamic shape optimization of a supersonic transport including a subsonic static margin constraint](https://doi.org/10.1016/j.ast.2025.110565)
+   Seraj, S., Yildirim, A., and Martins, J. R. R. A. (MDO Lab, University of Michigan),
+   *Aerospace Science and Technology*, Vol. 166, 2025, Art. 110565.
+   doi:10.1016/j.ast.2025.110565. 26 pp.
+   Three-surface supersonic transport optimized under a subsonic static margin constraint.
+   The central lesson is coupling: optimize for supersonic cruise alone and the low-speed
+   stability becomes unacceptable. See also [Aerodynamics]({{ site.baseurl }}/aerodynamics/).
+   `Publisher`
+
+### Secondary References
+
+1. **CAS-SST-S01** — [Aerodynamic Shape Optimization of a Supersonic Transport Considering Low-Speed Stability](https://doi.org/10.2514/6.2022-2177)
+   Seraj, S., and Martins, J. R. R. A., AIAA Paper 2022-2177, AIAA SciTech Forum, 2022.
+   The earlier conference treatment of CAS-SST-P01.
+   `Publisher`
+
+2. **CAS-SST-S02** — Lockheed Martin X-59 Structure and Configuration Layout
+   *Aviation Week & Space Technology*, 9–22 March 2026.
+   Structure and configuration layout figure for the X-59 QueSST low-boom demonstrator.
+   Subscription required.
+   `Publisher`
+
+---
+
+## Topic: Homeland Defense Interceptor (INT)
+
+### Primary References
+
+1. **CAS-INT-P01** — [Student aircraft design teams take 1st and 2nd in AIAA competition](https://aerospace.illinois.edu/news/78344)
+   Levey Larson, D., Dept. of Aerospace Engineering, The Grainger College of Engineering,
+   University of Illinois Urbana-Champaign, 21 October 2025.
+   The 1st place (Homelander) and 2nd place (QF-49 Dragonfly) entries in the AIAA
+   Undergraduate Team Aircraft Design Competition — design a small, high-performance,
+   low-cost homeland defense interceptor to replace the F-22 and F-35 by 2045. The teams'
+   own account of the three hardest constraints: minimizing cost, hitting the instantaneous
+   turn rate requirement, and fuel volume placement. **Read this before starting a
+   competition entry.**
+   `Open`
+
+### Secondary References
+
+1. **CAS-INT-S01** — [Eastern Jet with a Western Makeover (Aero L-39 Albatros)](https://www.aopa.org/news-and-media/all-news/2024/september/pilot/l-39-albatros-eastern-jet-with-a-western-makeover)
+   Hirschman, D., *AOPA Pilot*, September 2024.
+   Westernized L-39 Albatros — a relevant reference aircraft for the low-cost light
+   jet / trainer / light attack class, and a useful illustration of how much of an aircraft's
+   cost sits in its systems rather than its airframe.
+   `Open`
+
+---
+
+## Topic: Transport Aircraft (TRN)
+
+### Primary References
+
+1. **CAS-TRN-P01** — [Boeing 787 Lessons Learnt](http://wpage.unina.it/fabrnico/DIDATTICA/PGV_2012/MAT_DID_CORSO/Design_Cases/Boeing_787_Lessons_learnt.pdf)
+   Domke, B., *TI — Boeing 787 Lessons Learnt*, Ref. PR0813399, Issue 2, Engineering
+   Intelligence / Future Projects Office, Airbus, October 2008. 46 pp.
+   Airbus's internal competitive assessment of the 787 programme — design, weight,
+   performance, structures, manufacturing, supply chain and production status. Unusually
+   candid, and one of the few places you can see a manufacturer's real assessment of a
+   competitor's design decisions and their consequences.
+   `Open`
+
+### Secondary References
+
+1. **CAS-TRN-S01** — [Airbus A380 Presentation](http://wpage.unina.it/fabrnico/DIDATTICA/PGV_2012/MAT_DID_CORSO/Design_Cases/Airbus%20A380%20Presentation.pps)
+   Airbus A380 design case study presentation (PowerPoint), Università di Napoli Federico II
+   aircraft design course collection.
+   Configuration and design overview of the A380. Pair with the market-forecast reasoning
+   that justified it — and with the programme's eventual outcome — as a case study in
+   requirements risk.
+   `Open`
+
+2. **CAS-TRN-S02** — [Boeing 777 (Airliner Tech Series)](http://wpage.unina.it/fabrnico/DIDATTICA/PGV_2012/MAT_DID_CORSO/Design_Cases/%5bAviation%5d%20-%20%5bAirliner%20Tech%20n%b002%5d%20-%20Boeing%20777.pdf)
+   *Airliner Tech Series, Vol. 2: Boeing 777*.
+   Detailed configuration and systems description of the 777. Useful reference-aircraft
+   data for a widebody transport project.
+   `Open`
+
+---
+
+## Topic: Uncrewed Aircraft Systems (UAS)
+
+### Primary References
+
+1. **CAS-UAS-P01** — [Conceptual Design of Uninhabited Aircraft for Support of Wildfire Suppression](https://ntrs.nasa.gov/api/citations/20260000623/downloads/tvf2026_WildfireSuppression.pdf)
+   Silva, C., and Solis, E. (NASA Ames), VFS, January 2026.
+   Cross-listed from Aerial Firefighting above — it is the best sUAS design process
+   example in this library regardless of mission.
+   `Open`
+
+2. **CAS-UAS-P02** — [Designing Unmanned Aircraft Systems: A Comprehensive Approach](https://doi.org/10.2514/4.868443)
+   Gundlach, J., *Designing Unmanned Aircraft Systems: A Comprehensive Approach*, AIAA
+   Education Series, AIAA, Reston, VA, 2012. doi:10.2514/4.868443
+   (2nd ed., 2014, doi:[10.2514/4.102615](https://doi.org/10.2514/4.102615).)
+   The design text for uncrewed aircraft, and the only one that treats the *system* —
+   air vehicle, payload, data link, control station, launch and recovery — as the thing
+   being designed. Its sizing method differs from the crewed one in ways that matter:
+   endurance-driven sizing, payload-first layout, and no crew-station constraint. Use it in
+   place of [FND-TXT-P01]({{ site.baseurl }}/foundations/) if your RFP is uncrewed.
+   VT access: [Knovel (VT sign-in)](https://app-knovel-com.ezproxy.lib.vt.edu/web/toc.v/cid:kpDUASACA1/viewerType:toc//root_slug:designing-unmanned-aircraft)
+   `Publisher`
+
+### Secondary References
+
+1. **CAS-UAS-S01** — [Applications and Assessments of Uncrewed Aerial Vehicles for Dual-Use Public Good and Military Missions](https://ntrs.nasa.gov/api/citations/20260000574/downloads/TVF26_Dual_Use.pdf)
+   Scott, R., and Conley, S. (NASA Ames), VFS, January 2026.
+   `Open`

--- a/references/configuration-fuselage.md
+++ b/references/configuration-fuselage.md
@@ -1,0 +1,73 @@
+---
+layout: default
+title: Configuration & Fuselage
+nav_order: 6
+permalink: /configuration-fuselage/
+---
+
+# Configuration & Fuselage
+{: .no_toc }
+
+Cabin cross-section, fuselage length and shape, and the configuration decisions that lock
+in most of your later constraints.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Fuselage & Cabin Layout (FUS)
+
+### Primary References
+
+1. **CFG-FUS-P01** — [Cabin Layout and Fuselage Geometry](http://wpage.unina.it/fabrnico/DIDATTICA/PGV_2012/MAT_DID_CORSO/07_Prog_Fusoliera/Fuselage_Design_Stanford.pdf)
+   Kroo, I., and Shevell, R. S., "Cabin Layout and Fuselage Geometry," in *Aircraft Design:
+   Synthesis and Analysis*, Desktop Aeronautics / Stanford University AA241. 51 pp.
+   The most directly usable of the fuselage references: cabin cross-section selection,
+   fuselage length and fineness ratio, FAR-driven layout constraints, and how each choice
+   feeds back into drag. Start here.
+   Mirrored by the Università di Napoli Federico II aircraft design course; the original
+   Stanford site is no longer reachable.
+   `Open`
+
+2. **CFG-FUS-P02** — [Fuselage Design (Torenbeek)](http://wpage.unina.it/fabrnico/DIDATTICA/PGV_2012/MAT_DID_CORSO/07_Prog_Fusoliera/Fuselage_Design_Torenbeek.pdf)
+   Torenbeek, E., "Fuselage Design," Ch. 3 in *Synthesis of Subsonic Airplane Design*,
+   Delft University Press / Springer, 1982. 35 pp.
+   The statistical and empirical treatment. More correlations and more design data than
+   CFG-FUS-P01, and the source most later textbooks are quietly reproducing. Use for
+   cross-checking numbers.
+   {: .warning }
+   > Scan of a copyrighted textbook hosted on a university course page. Cite the book:
+   > Torenbeek, E., *Synthesis of Subsonic Airplane Design*, Delft University Press, 1982,
+   > ISBN 978-90-247-2724-5. Publisher listing:
+   > [link.springer.com/book/10.1007/978-94-017-3202-4](https://link.springer.com/book/10.1007/978-94-017-3202-4)
+
+   `Open`
+
+---
+
+## Topic: Configuration Selection (SEL)
+
+### Secondary References
+
+1. **CFG-SEL-S01** — [Configurations (Torenbeek Ch. 2)](http://wpage.unina.it/fabrnico/DIDATTICA/PGV_2012/MAT_DID_CORSO/13_Configurazioni/CAP2_Torenbeek.pdf)
+   Torenbeek, E., "General Aspects of Aircraft Configuration Development," Ch. 2 in
+   *Synthesis of Subsonic Airplane Design*, Delft University Press, 1982.
+   Wing position, engine placement, tail arrangement and landing gear layout, with the
+   trade reasoning for each. The chapter to read before you commit to a general arrangement.
+   {: .warning }
+   > Scan of a copyrighted textbook hosted on a university course page. Cite the book.
+
+   `Open`
+
+2. **CFG-SEL-S02** — [Lockheed Martin X-59 Structure and Configuration Layout](https://aviationweek.com/aviation-week-space-technology)
+   "X-59 structure and configuration layout," *Aviation Week & Space Technology*,
+   9–22 March 2026.
+   Cutaway-style structural and configuration layout of the X-59 QueSST. Valuable as an
+   example of how a real configuration layout drawing is presented. Subscription required.
+   `Publisher`
+
+3. **CFG-SEL-S03** — [Enhanced Conceptual Wing Weight Estimation Through Structural Optimization and Simulation](https://labs.engineering.asu.edu/aircraft-design/wp-content/uploads/sites/115/2023/03/AIAA-2010-9075-Structural-Design-and-Weight-Estimation.pdf)
+   See [Structures & Weights]({{ site.baseurl }}/structures-weights/) — the structural
+   arrangement discussion is directly relevant to configuration layout.
+   `Open`

--- a/references/cost.md
+++ b/references/cost.md
@@ -1,0 +1,140 @@
+---
+layout: default
+title: Cost & Value
+nav_order: 10
+permalink: /cost/
+---
+
+# Cost & Value
+{: .no_toc }
+
+Development and production cost, direct operating cost, and the value argument that
+decides whether a design is worth building.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Development & Production Cost (DPC)
+
+### Primary References
+
+1. **CST-DPC-P01** — [DAPCA: A Computer Program for Determining Aircraft Development and Production Costs](https://www.rand.org/content/dam/rand/pubs/research_memoranda/2006/RM5221.pdf)
+   Boren, H. E., Jr., *DAPCA: A Computer Program for Determining Aircraft Development and
+   Production Costs*, RM-5221-PR, RAND Corporation, Santa Monica, CA, 1967. 93 pp.
+   The original DAPCA. Every "RAND DAPCA-IV" cost model in every design textbook descends
+   from this. Inputs are physical characteristics — gross takeoff weight, speed, engine
+   type and count, thrust. Appendices give the full costing equations, flowcharts, and the
+   FORTRAN IV source. Worth reading to see what the modern cost equations are actually
+   approximating.
+   Landing page: [rand.org/pubs/research_memoranda/RM5221.html](https://www.rand.org/pubs/research_memoranda/RM5221.html)
+   `Open`
+
+### Secondary References
+
+1. **CST-DPC-S01** — [A Computer Model for Estimating Development and Procurement Costs of Aircraft (DAPCA-III)](https://www.rand.org/pubs/reports/R1854.html)
+   Boren, H. E., Jr., R-1854-PR, RAND Corporation, 1976.
+   The third-generation model. Closer to the cost estimating relationships you will find
+   reproduced in Raymer and Nicolai.
+   `Open`
+
+2. **CST-DPC-S02** — [Aircraft Airframe Cost Estimating Relationships](https://apps.dtic.mil/sti/tr/pdf/ADA212920.pdf)
+   Resetar, S. A., Rogers, J. C., and Hess, R. W., *Advanced Airframe Structures Materials:
+   A Primer and Cost Estimating Methodology*, R-3255-AF, RAND Corporation.
+   DTIC accession ADA212920.
+   Airframe CERs with material effects broken out — relevant if your design uses a
+   significant composite or titanium fraction and you need to defend the cost penalty.
+   `Open`
+
+---
+
+## Topic: Direct Operating Cost (DOC)
+
+### Primary References
+
+1. **CST-DOC-P01** — [Aircraft Cost Estimations (Jenkinson)](http://wpage.unina.it/fabrnico/DIDATTICA/PGV_2012/MAT_DID_CORSO/08_Prestazioni/DOC_Jenkinson.pdf)
+   Jenkinson, L. R., Simpkin, P., and Rhodes, D., "Aircraft Cost Estimations," in
+   *Civil Jet Aircraft Design*, Arnold / AIAA Education Series, 1999.
+   ISBN 978-0-340-74152-8. doi:10.2514/4.473500. 24 pp.
+   The most directly usable DOC method for a student project: complete, self-contained,
+   with a specimen calculation and reference data explicitly intended for student work.
+   Covers the main DOC elements and touches indirect costs. **Start here.**
+   {: .warning }
+   > Scan of a copyrighted textbook hosted on a university course page. Cite the book.
+   > [Publisher listing](https://arc.aiaa.org/doi/10.2514/4.473500)
+
+   `Open`
+
+### Secondary References
+
+1. **CST-DOC-S01** — [Comparative Analysis on Aircraft Direct Operating Cost Models](https://doi.org/10.2514/6.2025-3499)
+   Espinosa-Juárez, E., Jouannet, C., Amadori, K., and Sánchez Mata, A., "Comparative
+   Analysis on Aircraft Direct Operating Cost Models," AIAA Paper 2025-3499,
+   *AIAA AVIATION Forum and ASCEND*, Las Vegas, NV, 21–25 July 2025. 25 pp.
+   doi:10.2514/6.2025-3499
+   Reviews nine DOC models and shows how far apart their estimates are — important context
+   before you quote a single DOC number to three significant figures. Proposes a model for
+   smaller and electrified aircraft, adding battery depreciation and degradation, amortized
+   interest, SAF blending and carbon tax.
+   `Publisher`
+
+2. **CST-DOC-S02** — [Evaluating hybrid-electric aircraft viability: The Ampaire Eco Caravan cost analysis](https://doi.org/10.1016/j.trd.2025.104759)
+   Cusati, V., Di Stasio, M., Lucci, G., and Zhang, Q., "Evaluating hybrid-electric aircraft
+   viability: The Ampaire Eco Caravan cost analysis," *Transportation Research Part D:
+   Transport and Environment*, Vol. 144, 2025, Art. 104759.
+   doi:10.1016/j.trd.2025.104759
+   Full DOC analysis of a real hybrid-electric retrofit (Cessna 208B Grand Caravan). Fuel
+   and emissions down ~50%, operating costs down 9%, but acquisition cost pushes total DOC
+   *up* 3%. A clean worked example of why a technology that improves every physical metric
+   can still fail the business case. **Open access (CC BY).**
+   `Open`
+
+3. **CST-DOC-S03** — [Air Cargo Economics](https://ocw.mit.edu/courses/16-886-air-transportation-systems-architecting-spring-2004/resources/06cargo_econmics/)
+   Clarke, J.-P., *Air Cargo Economics*, Lecture 6, 16.886 Air Transportation Systems
+   Architecting, MIT, 24 February 2004. MIT OpenCourseWare.
+   DOC from the operator's side for cargo operations. See also
+   [Operations, Market & Environment]({{ site.baseurl }}/operations-environment/).
+   `Open`
+
+---
+
+## Topic: Life-Cycle Cost & Value (LCV)
+
+### Primary References
+
+1. **CST-LCV-P01** — [Cost and Financial Analysis](https://ocw.mit.edu/courses/16-885j-aircraft-systems-engineering-fall-2004/dfeae3bb47e8b5e6b562a0159ee2cccb_pres_willcox.pdf)
+   Willcox, K., *Cost Analysis*, Lecture 4, 16.885J Aircraft Systems Engineering, MIT,
+   Fall 2004. MIT OpenCourseWare. 51 pp.
+   Lifecycle cost, operating cost, development cost, manufacturing cost and revenue
+   valuation in one lecture, framed around the design decisions that drive each. The
+   clearest short overview of the whole cost picture.
+   `Open`
+
+2. **CST-LCV-P02** — [Design of Aircraft for Best Value](https://doi.org/10.2514/1.C036012)
+   Bevilaqua, P. M., "Design of Aircraft for Best Value," *Journal of Aircraft*, 2021.
+   doi:10.2514/1.C036012. 12 pp.
+   The argument for why "maximum performance" and "minimum cost" are both wrong objectives.
+   Uses operations analysis and parametric costing to weigh added performance against its
+   cost, including the hidden cost of buying fewer aircraft when unit cost rises. Written by
+   the designer of the F-35B lift-fan system.
+   `Publisher`
+
+### Secondary References
+
+1. **CST-LCV-S01** — [COCOMO: A procedural cost estimate model for software projects](https://medium.com/@warakornjetlohasiri/cocomo-a-regression-model-in-procedural-cost-estimate-model-for-software-projects-65ab5222a1f5)
+   Jetlohasiri, W., "COCOMO: A procedural cost estimate model for software projects."
+   Overview of Boehm's COCOMO model — organic, semi-detached and embedded project classes,
+   and the effort/schedule relations. Relevant because avionics and mission-system software
+   is now a large and frequently underestimated share of development cost. See also the
+   [Wikipedia article on COCOMO](https://en.wikipedia.org/wiki/COCOMO) and Boehm, B. W.,
+   *Software Engineering Economics*, Prentice-Hall, 1981.
+   `Open`
+
+2. **CST-LCV-S02** — Airframe Development Cost Calculator (CSGNetwork)
+   Online DAPCA-style airframe development cost calculator.
+   {: .warning }
+   > The host `csgnetwork.com/airframedevcalc.html` is no longer reachable. Use CST-DPC-P01
+   > directly, or the DAPCA-IV equations as reproduced in Raymer.
+
+   `Citation only`

--- a/references/course-modules.md
+++ b/references/course-modules.md
@@ -1,0 +1,172 @@
+---
+layout: default
+title: Course Modules
+nav_order: 2
+permalink: /course-modules/
+---
+
+# Course Modules
+{: .no_toc }
+
+The complete set of AVD course modules developed by **Prof. Pradeep Raj**, who taught
+AOE 4065/4066 from 2011–12 through 2023–24. Twenty-two module decks in three groups,
+released publicly on his
+[Air Vehicle Design page](https://www.aoe.vt.edu/people/emeritus/raj/air-vehicle-design.html).
+
+These are the closest thing this library has to a spine: they follow the course
+week by week, and most of the topic pages in this library extend a method that first
+appears in one of them.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Module Sets (SET)
+
+### Primary References
+
+1. **MOD-SET-P01** — [I. Foundational Elements](https://drive.google.com/drive/folders/1Lgo1VIknVnV2VgpqyyGiR6fykZN5Y2AR)
+   Raj, P., *Air Vehicle Design Course Modules, Group I: Foundational Elements*,
+   Kevin T. Crofton Dept. of Aerospace and Ocean Engineering, Virginia Tech. 4 modules.
+   What design *is* as an engineering activity, before any aircraft is drawn. Read these
+   in the first two weeks — the vocabulary they set up (system, stakeholder, requirement,
+   trade) is used throughout the rest of the course.
+   - [F1 — Design: An Engineering Discipline](https://drive.google.com/file/d/1WZzoMhoxQcZgCjgjPb7mUXnUZc1PSA1t/view)
+   - [F2 — Systems and Systems Thinking](https://drive.google.com/file/d/1PmOQ085bw6qici2oYrmBOfXEbJ6oIZJL/view)
+   - [F3 — Basics of Systems Engineering](https://drive.google.com/file/d/1VEnle6NYG8SBUGCHV2_ShGEVQY0jBOCP/view)
+   - [F4 — Decision-Making with Ethics and Integrity](https://drive.google.com/file/d/1jwZi6YNNTAicpIWK2j2WDrD2MAFd-2ZU/view)
+
+   Background reading for this group is on the
+   [Foundations]({{ site.baseurl }}/foundations/) page under *Engineering Design &
+   Decision Making* and *Systems Thinking & Systems Engineering*; F4 pairs with
+   [Project Management & Ethics]({{ site.baseurl }}/project-management-ethics/).
+   `Open`
+
+2. **MOD-SET-P02** — [II. Air Vehicle Design Fundamentals](https://drive.google.com/drive/folders/1Q21SyxDsSnBUfsXAXoDYnBbtHuD2lspB)
+   Raj, P., *Air Vehicle Design Course Modules, Group II: Air Vehicle Design Fundamentals*,
+   Kevin T. Crofton Dept. of Aerospace and Ocean Engineering, Virginia Tech. 11 modules.
+   The technical core, in the order the design actually proceeds: understand the problem,
+   size it, cost it, lay it out, trade it, refine it. **A4 and A5 are the two you will
+   return to most** — they are the initial sizing loop.
+   - [A1 — AVD Purpose and Process](https://drive.google.com/file/d/1J5xBo3nCqmSBkqqSnkzRQIDsBJq-zQTm/view)
+   - [A2 — Understand the Design Problem](https://drive.google.com/file/d/1YN3pyJ-xhwp2DOS6HUZYSAkgdHD8synO/view)
+   - [A3 — Solve the Problem: Design Baseline Configuration](https://drive.google.com/file/d/1Qx4l4zkUsyfxjI0E_YyP6JzVCAIV2k5f/view)
+   - [A4 — Initial Sizing: Takeoff Weight Estimation](https://drive.google.com/file/d/1W1LuutIIkBs8lgQK1hrl2JumKp56oOU8/view)
+   - [A5 — Initial Sizing: Wing Loading and Thrust Loading Estimation](https://drive.google.com/file/d/1-erc2nfvt9W22tcnEJqLafRVQdu6SXgL/view)
+   - [A6 — Cost Estimation](https://drive.google.com/file/d/1BnE6t_bNa-Ez0zDGUM3tR2CnXNJ3eRiu/view)
+   - [A7 — Concept to Configuration: Key Considerations](https://drive.google.com/file/d/1yTkc1U0cM7lT0wcWvToCqevaHUNhRsCo/view)
+   - [A7a — Configuration Layout: Drawings and Loft](https://drive.google.com/file/d/1MHEm2GEApGxpduFbghQp4xcwaUqKI4XV/view)
+   - [A8 — Trade Studies](https://drive.google.com/file/d/1GhFXDK3QcvJWXdeiF1pmUHvYABObQHo3/view)
+   - [A9 — Use of Software Tools](https://drive.google.com/file/d/1yQlULdci6G6OqTfX7ac05xRM1Lkd_FU6/view)
+   - [A10 — Preliminary Design: Refine and Validate Baseline Design](https://drive.google.com/file/d/1FOoNSPwe3lQ_XInlBZRL07XWGNu_ftIs/view)
+
+   A6 pairs with the [Cost & Value]({{ site.baseurl }}/cost/) page; A7/A7a with
+   [Configuration & Fuselage]({{ site.baseurl }}/configuration-fuselage/); A4/A5 with
+   [Structures & Weights]({{ site.baseurl }}/structures-weights/) and
+   [Propulsion & Performance]({{ site.baseurl }}/propulsion-performance/).
+   `Open`
+
+3. **MOD-SET-P03** — [III. Project Management Topics](https://drive.google.com/drive/folders/18CKk8bhBXvxewdtn6At9EepQmLrqWL3q)
+   Raj, P., *Air Vehicle Design Course Modules, Group III: Project Management Topics*,
+   Kevin T. Crofton Dept. of Aerospace and Ocean Engineering, Virginia Tech. 7 modules.
+   How to run the project, not how to design the aircraft — planning, organization, roles,
+   risk, and the two deliverable skills the course is graded on. **P6 and P7 are worth
+   reading before your first review, not the night before.**
+   - [P1 — Project Management Basics and Project Planning](https://drive.google.com/file/d/1FvzSuCY6BwUbv43Rqjn7UcS9yL5s6Yp_/view)
+   - [P2 — Project Organization](https://drive.google.com/file/d/11ECMGNGl45FFuTxuLVAykbA254SiToWE/view)
+   - [P3 — Roles and Responsibilities of Project Team Members](https://drive.google.com/file/d/1iZH1H-2ZEtGlF3cIZ_yZRlaWxODA43_n/view)
+   - [P4 — Project Execution: Teamwork for Success](https://drive.google.com/file/d/1kax65A8vP0fhOBtKksux_Qh7QB06f3wI/view)
+   - [P5 — Project Risk Management](https://drive.google.com/file/d/15g7yreXmgV3ykQC8kBzquKuMlgGc9SyI/view)
+   - [P6 — Delivering Effective Oral Presentations](https://drive.google.com/file/d/1lsfCVlPV9D9fT4y8I1kxuKybmWEv9IOY/view)
+   - [P7 — Writing Effective Design Reports](https://drive.google.com/file/d/1G-0-Nutbsz3J4Q6D5X1RWyz5zW_F3HgT/view)
+
+   Supporting references are on the
+   [Project Management & Ethics]({{ site.baseurl }}/project-management-ethics/) page.
+   `Open`
+
+{: .note }
+> For the course overview, syllabus and schedule, go to **Canvas** — those are kept current
+> there, and any copy reproduced here would go stale.
+
+---
+
+## Crosswalk: Raj's reference numbers → this library
+
+If you are working from a slide deck that cites *AVD 2* or *AS 5*, this is where that
+reference now lives.
+
+The numbering comes from Raj's *AOE 4065-4066 List of Primary References* (August 2024):
+62 references in ten categories, hyperlinked through VT ezproxy so they only resolved on
+the campus network. Every one has been re-sourced to a public link and folded into the
+topic pages here.
+
+| Raj | Reference | Here |
+|-----|-----------|------|
+| GED 1 | Post, Brandt & Barlow, *Introduction to Engineering* | `FND-GED-S01` |
+| GED 2 | Brandt et al., *Introduction to Aeronautics* | `FND-TXT-S01` |
+| GED 3 | Dieter, *Engineering Design* | `FND-GED-S02` |
+| GED 4 | Ullman, *The Mechanical Design Process* | `FND-GED-S03` |
+| GED 5 | Ertas & Jones, *The Engineering Design Process* | `FND-GED-S04` |
+| GED 6 | Norman, *The Design of Everyday Things* | `FND-GED-S05` |
+| GED 7 | NRC, *Theoretical Foundations for Decision Making* | `FND-GED-P01` |
+| GED 8 | Woodson, *Introduction to Engineering Design* | `FND-GED-S06` |
+| SE 1 | Burge, *Systems Engineering / Systems Thinking* | `FND-SYS-S01` |
+| SE 2 | Kossiakoff & Sweet, *SE Principles and Practice* | `FND-SYS-S02` |
+| SE 3 | Haberfellner et al., *SE Fundamentals and Applications* | `FND-SYS-S03` |
+| SE 4 | NASA *Systems Engineering Handbook* | `FND-SYS-P01` |
+| SE 5 | DoD/DAU *Systems Engineering Fundamentals* | `FND-SYS-P02` |
+| AVD 1 | Nicolai & Carichner, *Fundamentals*, Vol. I | `FND-TXT-P02` |
+| AVD 2 | Raymer, *Aircraft Design: A Conceptual Approach* | `FND-TXT-P01` |
+| AVD 3 | Gundlach, *Designing Unmanned Aircraft Systems* | `CAS-UAS-P02` |
+| AVD 4 | Gudmundsson, *General Aviation Aircraft Design* | `FND-TXT-S03` |
+| AVD 5 | Sadraey, *Aircraft Design: A Systems Engineering Approach* | `FND-TXT-S02` |
+| AVD 6 | Kirschbaum & Mason, *Aircraft Design Handbook* (VPI) | — *not carried over* |
+| AVD 7 | Roskam, *Airplane Design*, Parts I–VIII | `FND-TXT-S07` |
+| AVD 8 | Kundu, *Aircraft Design* | `FND-TXT-S08` |
+| AVD 9 | Torenbeek, *Advanced Aircraft Design* | `FND-TXT-S06` |
+| AVD 10 | Loftin, *Subsonic Aircraft: Evolution and Matching* | `FND-CLS-S01` |
+| AVD 11 | Küchemann, *The Aerodynamic Design of Aircraft* | `AER-TXT-S03` |
+| AVD 12 | Corning, *Supersonic and Subsonic Airplane Design* | `FND-CLS-S04` |
+| AVD 13 | Schaufele, *Elements of Aircraft Preliminary Design* | `FND-TXT-S10` |
+| AVD 14 | Fielding, *Introduction to Aircraft Design* | `FND-TXT-S09` |
+| AVD 15 | Jenkinson, Simpkin & Rhodes, *Civil Jet Aircraft Design* | `FND-TXT-S04` |
+| AVD 16 | Stinton, *The Design of the Aeroplane* | `FND-CLS-S05` |
+| AVD 17 | Wood, *Aerospace Vehicle Design*, Vol. I | — *not carried over* |
+| AVD 18 | Raymer, *Enhancing Aircraft Conceptual Design using MDO* | `FND-OPT-S01` |
+| AVD 19 | Carichner & Nicolai, *Fundamentals*, Vol. II | `FND-CLS-S06` |
+| AVD 20 | Nicolai, *Lessons Learned* | `FND-CLS-S02` |
+| AVD 21 | Jenkinson & Marchman, *Aircraft Design Projects* | `FND-CLS-S03` |
+| AVD 22 | Torenbeek, *Synthesis of Subsonic Airplane Design* | `FND-TXT-S05` |
+| AERO 1 | Abbott & von Doenhoff, *Theory of Wing Sections* | `AER-TXT-P01` |
+| AERO 2 | Bertin, *Aerodynamics for Engineers* | `AER-TXT-S01` |
+| AERO 3 | Vos & Farokhi, *Introduction to Transonic Aerodynamics* | `AER-TXT-P02` |
+| AERO 4 | Rizzi & Oppelstrup, *Aircraft Aerodynamic Design* | `AER-TXT-S02` |
+| PS 1 | Mattingly, *Elements of Propulsion* | `PRP-TXT-P01` |
+| PS 2 | Oates, *Aircraft Propulsion Systems Technology and Design* | `PRP-TXT-S01` |
+| PS 3 | Mattingly, Heiser & Daley, *Aircraft Engine Design* | `FND-TXT-P03` |
+| PS 4 | Seddon & Goldsmith, *Intake Aerodynamics* | `PRP-TXT-S02` |
+| FM 1 | Pamadi, *Performance, Stability, Dynamics, and Control* | `STC-TXT-P01` |
+| FM 2 | Yechout et al., *Introduction to Aircraft Flight Mechanics* | `STC-TXT-P02` |
+| FM 3 | Stinton, *Flying Qualities and Flight Testing* | `STC-TXT-S01` |
+| FM 4 | Filippone, *Advanced Aircraft Flight Performance* | `PRP-PER-S02` |
+| STR 1 | Niu, *Airframe Structural Design* | `STW-TXT-P01` |
+| STR 2 | Niu, *Composite Airframe Structures* | `STW-TXT-S01` |
+| AS 1 | Moir & Seabridge, *Design and Development of Aircraft Systems* | `SUB-SYS-P01` |
+| AS 2 | Moir & Seabridge, *Aircraft Systems* | `SUB-SYS-P02` |
+| AS 3 | Moir, Seabridge & Jukes, *Civil Avionics Systems* | `SUB-AVI-P03` |
+| AS 4 | Moir & Seabridge, *Military Avionics Systems* | `SUB-AVI-S03` |
+| AS 5 | Currey, *Aircraft Landing Gear Design* | `SUB-LDG-P01` |
+| PM 1 | Ruskin & Estes, *What Every Engineer Should Know About PM* | `PMG-PRJ-S01` |
+| PM 2 | PMI, *PMBOK Guide* | `PMG-PRJ-S02` |
+| PM 3 | Haimes, *Risk Modeling, Assessment, and Management* | `PMG-PRJ-S03` |
+| EI 1 | Hoover, Fowler & Stearman, *Studies in Ethics, Safety, Liability* | `PMG-ETH-S01` |
+| EI 2 | Boisjoly, Curtis & Mellican, Challenger ethics paper | `PMG-ETH-P01` |
+| EI 3 | McDonald & Hansen, *Truth, Lies, and O-Rings* | `PMG-ETH-P02` |
+| EI 4 | *Professionalism / The Ford Pinto Gas Tank Controversy* | `PMG-ETH-S02` |
+| EI 5 | Atiyeh, VW diesel-emissions scandal | `PMG-ETH-S03` |
+
+{: .note }
+> Raj's list linked most of these through VT library subscriptions. Those links are
+> preserved on the individual entries as a **VT access** line, alongside a public DOI or
+> publisher link that works for everyone.

--- a/references/electrified-aircraft.md
+++ b/references/electrified-aircraft.md
@@ -1,0 +1,82 @@
+---
+layout: default
+title: Electrified Aircraft
+nav_order: 14
+permalink: /electrified-aircraft/
+---
+
+# Electrified Aircraft
+{: .no_toc }
+
+Terminology, powertrain weight and efficiency models, and the sizing consequences of
+electric and hybrid-electric propulsion.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Terminology & Architecture (LEX)
+
+### Primary References
+
+1. **ELA-LEX-P01** — [Electric Aircraft and Powertrain Lexicon, Part 1](https://vtol.org/store/product/vertiflite-januaryfebruary-2026-1919.cfm)
+   Lawless, A., and Schmidt, P., "Electric Aircraft and Powertrain Lexicon, Part 1,"
+   *Vertiflite*, Vol. 72, No. 1, January/February 2026, Vertical Flight Society. 7 pp.
+   Standardized terminology for electric and hybrid-electric aircraft, built on four
+   framework anchors and separating airplane-level from powertrain-level description.
+   Produced by the VFS Electric Flight Test Committee to stop every organization inventing
+   its own architecture vocabulary. **Use these definitions in your report** so that
+   "series hybrid" means the same thing to you and your reviewers.
+   `Publisher`
+
+### Secondary References
+
+1. **ELA-LEX-S01** — [VTOL Aircraft Taxonomy and Lexicon](https://evtol.news/__media/PDFs/VTOL-Taxonomy-and-Lexicon.pdf)
+   Vertical Flight Society, *VTOL Aircraft Taxonomy and Lexicon*.
+   Companion taxonomy on the configuration side — multirotor, lift+cruise, tiltrotor,
+   tiltwing and the rest, defined consistently. Freely available.
+   `Open`
+
+---
+
+## Topic: Powertrain Modelling (PWR)
+
+### Primary References
+
+1. **ELA-PWR-P01** — A Comparison of Electric Powertrain Models for Conceptual Design of a Distributed Lift Aircraft
+   Beals, N. (DEVCOM Army Research Laboratory), Vegh, J. M. (U.S. Army CCDC Aviation and
+   Missile Center), and Basset, P.-M. (ONERA, The French Aerospace Lab),
+   "A Comparison of Electric Powertrain Models for Conceptual Design of a Distributed Lift
+   Aircraft," Vertical Flight Society. 11 pp.
+   Compares powertrain weight and efficiency models across three conceptual design tools —
+   HYDRA, NDARC and CREATION — on a common lift+cruise vehicle and mission, and shows how
+   much of your sized vehicle weight is an artifact of which motor, ESC and battery model
+   you happened to pick. No public copy located.
+   `Citation only`
+
+### Secondary References
+
+1. **ELA-PWR-S01** — [A comparison of three conceptual design approaches applied to an electric distributed lift aircraft](https://doi.org/10.1007/s13272-024-00766-2)
+   Vegh, J. M., Beals, N., Basset, P.-M., et al., *CEAS Aeronautical Journal*, 2025.
+   doi:10.1007/s13272-024-00766-2
+   The journal treatment of the same comparison. Use this where ELA-PWR-P01 is unavailable.
+   `Publisher`
+
+2. **ELA-PWR-S02** — [Preliminary Sizing of an eVTOL Lift-Cruise Aircraft](https://doi.org/10.21203/rs.3.rs-4099036/v1)
+   Heidary, M., and Kosari, A., *Preliminary Sizing of an eVTOL Lift-Cruise Aircraft*,
+   preprint, University of Tehran, Research Square, 25 March 2024.
+   doi:10.21203/rs.3.rs-4099036/v1. 22 pp.
+   Matching-diagram method extended to an aircraft that has to satisfy both fixed-wing and
+   rotary-wing performance constraints. Directly usable if your project is a lift+cruise
+   eVTOL. **Open access (CC BY).** Preprint — not peer reviewed.
+   Direct PDF: [assets-eu.researchsquare.com](https://assets-eu.researchsquare.com/files/rs-4099036/v1_covered_1b503c69-be59-486c-9865-d05bf275d5d8.pdf)
+   `Open`
+
+3. **ELA-PWR-S03** — [eVTOL Performance Analysis: A Review From Control Perspectives](https://ieeexplore.ieee.org/document/10496812/)
+   Su, J., Huang, H., Zhang, H., Wang, Y., and Wang, F.-Y., "eVTOL Performance Analysis:
+   A Review From Control Perspectives," *IEEE Transactions on Intelligent Vehicles*, 2024.
+   Systematic comparison of multirotor, lift+cruise and tiltrotor eVTOL configurations,
+   with the advantages and limitations of each — framed around control and transition,
+   which is where these configurations actually differ.
+   `Publisher`

--- a/references/foundations.md
+++ b/references/foundations.md
@@ -1,0 +1,399 @@
+---
+layout: default
+title: Foundations & Design Process
+nav_order: 3
+permalink: /foundations/
+---
+
+# Foundations & Design Process
+{: .no_toc }
+
+Textbooks and complete design methodologies. Start here — these carry you through the
+whole process, and most of the topic-specific references below extend a method that
+first appears in one of these.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Core Textbooks (TXT)
+
+The three primary entries are the course's core texts. Everything under *Secondary* is a
+real alternative or a second opinion — useful, but not what you are expected to work from.
+
+### Primary References
+
+1. **FND-TXT-P01** — [Aircraft Design: A Conceptual Approach](https://doi.org/10.2514/4.107290)
+   Raymer, D. P., *Aircraft Design: A Conceptual Approach*, 7th ed., AIAA Education Series,
+   AIAA, Reston, VA, 2024. doi:10.2514/4.107290
+   **The single most important reference in this library.** The source of the drag build-up,
+   weight equations and sizing procedure that your project will run on. Its worked "design
+   examples" chapter is the best model available for how the pieces fit together in
+   sequence. If you only ever open one book on this list, open this one.
+   The 5th edition (2012, doi:[10.2514/4.869112](https://doi.org/10.2514/4.869112)) is the
+   one on Raj's list.
+   `Publisher`
+
+2. **FND-TXT-P02** — [Fundamentals of Aircraft and Airship Design, Vol. I — Aircraft Design](https://doi.org/10.2514/4.867538)
+   Nicolai, L. M., and Carichner, G. E., *Fundamentals of Aircraft and Airship Design,
+   Volume I: Aircraft Design*, AIAA Education Series, AIAA, Reston, VA, 2010.
+   doi:10.2514/4.867538
+   The most complete single treatment of the conceptual design loop, written by someone who
+   ran it in industry for decades. Stronger than most on military missions, on the
+   constraint-analysis/sizing pair, and on why a method's error band matters more than its
+   elegance. Read alongside FND-TXT-P01 — where they differ, the difference is usually
+   instructive. Airship volume is [FND-CLS-S06](#topic-classic--specialist-design-texts-cls).
+   VT access: [Knovel (VT sign-in)](https://app-knovel-com.ezproxy.lib.vt.edu/web/toc.v/cid:kpFAADVIA3/viewerType:toc//root_slug:fundamentals-aircraft-2/url_slug:fundamentals-aircraft-2)
+   `Publisher`
+
+3. **FND-TXT-P03** — [Aircraft Engine Design](https://arc.aiaa.org/doi/book/10.2514/4.105173)
+   Mattingly, J. D., Heiser, W. H., and Pratt, D. T., *Aircraft Engine Design*, 3rd ed.,
+   AIAA Education Series, AIAA, Reston, VA, 2018. doi:10.2514/4.105173
+   (2nd ed., Mattingly, Heiser and Daley, 2002,
+   doi:[10.2514/4.861444](https://doi.org/10.2514/4.861444).)
+   The engine-side mirror of your own process: constraint analysis and mission analysis run
+   for the engine rather than the airframe. Its constraint-analysis chapter is the clearest
+   version of that method in print, and worth reading even if you are selecting an existing
+   engine rather than sizing a notional one. Supporting propulsion references are on the
+   [Propulsion & Performance]({{ site.baseurl }}/propulsion-performance/) page.
+   VT access: [Knovel (VT sign-in)](https://app-knovel-com.ezproxy.lib.vt.edu/web/view/khtml/show.v/rcid:kpAEDE000J/cid:kt0046IK63/viewerType:khtml//root_slug:aircraft-engine-design/url_slug:front-matter)
+   `Publisher`
+
+### Secondary References
+
+1. **FND-TXT-S01** — [Introduction to Aeronautics: A Design Perspective](https://arc.aiaa.org/doi/book/10.2514/4.103278)
+   Brandt, S. A., Stiles, R. J., Bertin, J. J., and Whitford, R., *Introduction to Aeronautics:
+   A Design Perspective*, 3rd ed., AIAA Education Series, AIAA, Reston, VA.
+   The broadest single entry point: aerodynamics, propulsion, performance, stability and
+   structures, all framed around design decisions rather than analysis for its own sake.
+   Best used to refresh a discipline you have not touched since the sophomore course.
+   VT access: [Knovel (VT sign-in)](https://app-knovel-com.ezproxy.lib.vt.edu/kn/resources/kpIAADPE01/toc)
+   `Publisher`
+
+2. **FND-TXT-S02** — [Aircraft Design: A Systems Engineering Approach](https://www.wiley.com/en-us/Aircraft+Design:+A+Systems+Engineering+Approach-p-9780470978443)
+   Sadraey, M. H., *Aircraft Design: A Systems Engineering Approach*, John Wiley & Sons,
+   Chichester, 2012. ISBN 978-0-470-97844-3.
+   Treats the aircraft as a system and works through each component design in sequence.
+   Strong on requirements flow-down and on design of individual surfaces. The tail design
+   chapter is listed separately under [Stability & Control]({{ site.baseurl }}/stability-control/).
+   VT access: [Wiley Online Library (VT sign-in)](https://onlinelibrary-wiley-com.ezproxy.lib.vt.edu/doi/book/10.1002/9781118352700)
+   `Publisher`
+
+3. **FND-TXT-S03** — [General Aviation Aircraft Design: Applied Methods and Procedures](https://www.sciencedirect.com/book/9780123973085)
+   Gudmundsson, S., *General Aviation Aircraft Design: Applied Methods and Procedures*,
+   Butterworth-Heinemann, Oxford, 2014. ISBN 978-0-12-397308-5. (2nd ed., 2022.)
+   The most *implementable* of the design texts: nearly every method arrives as an explicit
+   procedure with worked numbers and, often, sample code. Aimed at general aviation, but the
+   drag, performance and stability methods generalize. Use it when Raymer tells you what to
+   do and you need someone to show you how.
+   VT access: [ScienceDirect (VT sign-in)](https://www-sciencedirect-com.ezproxy.lib.vt.edu/book/9780123973085/general-aviation-aircraft-design)
+   `Publisher`
+
+4. **FND-TXT-S04** — [Civil Jet Aircraft Design](https://doi.org/10.2514/4.473500)
+   Jenkinson, L. R., Simpkin, P., and Rhodes, D., *Civil Jet Aircraft Design*, AIAA,
+   Reston, VA, 1999. doi:10.2514/4.473500
+   The transport-specific counterpart to FND-TXT-P01. If your RFP is a civil transport, this
+   is the closest match to your problem — cabin layout, field performance, and the operating
+   economics that decide the configuration. Its data appendices are cited separately on the
+   [Cost & Value]({{ site.baseurl }}/cost/) page.
+   `Publisher`
+
+5. **FND-TXT-S05** — [Synthesis of Subsonic Airplane Design](https://link.springer.com/book/10.1007/978-94-017-3202-4)
+   Torenbeek, E., *Synthesis of Subsonic Airplane Design*, Delft University Press /
+   Springer, 1982. ISBN 978-90-247-2724-5.
+   The classic reference for statistical and empirical preliminary design methods. Dense,
+   but the source of a large fraction of the correlations used in every later textbook.
+   Also available via the [Internet Archive](https://archive.org/details/SynthesisOfSubsonicAirplaneDesign).
+   `Publisher`
+
+6. **FND-TXT-S06** — [Advanced Aircraft Design](https://doi.org/10.1002/9781118568101)
+   Torenbeek, E., *Advanced Aircraft Design: Conceptual Design, Analysis and Optimization of
+   Subsonic Civil Airplanes*, John Wiley & Sons, Chichester, 2013.
+   doi:10.1002/9781118568101
+   Torenbeek's later book, and a different one from FND-TXT-S05: analytical optimization
+   rather than statistics. Derives closed-form optima for wing loading, aspect ratio and
+   cruise condition, so you can see which parameters the optimum is actually sensitive to.
+   VT access: [Wiley Online Library (VT sign-in)](https://onlinelibrary-wiley-com.ezproxy.lib.vt.edu/doi/book/10.1002/9781118568101)
+   `Publisher`
+
+7. **FND-TXT-S07** — [Airplane Design, Parts I–VIII](https://shop.darcorp.com/index.php?route=product/category&path=85_60)
+   Roskam, J., *Airplane Design, Parts I–VIII*, Roskam Aviation and Engineering Corp.,
+   Lawrence, KS, 1985 (DARcorporation).
+   Eight volumes, each covering one stage: sizing (I), configuration and propulsion
+   integration (II), cockpit/fuselage/wing/empennage layout (III), landing gear and systems
+   (IV), component weights (V), aerodynamic and thrust characteristics (VI), stability and
+   control (VII), cost (VIII). Not a book to read — a book to look things up in, and the
+   most exhaustive layout and weights data in the list.
+   `Publisher`
+
+8. **FND-TXT-S08** — [Aircraft Design](https://doi.org/10.1017/cbo9780511844652)
+   Kundu, A. K., *Aircraft Design*, Cambridge Aerospace Series, Cambridge University Press,
+   2010. doi:10.1017/CBO9780511844652
+   Written from a manufacturer's standpoint, with unusually direct treatment of
+   manufacturing considerations, cost, and the Airbus/Boeing-style industrial process.
+   Good on where design freedom is actually lost.
+   VT access: [Knovel (VT sign-in)](https://app-knovel-com.ezproxy.lib.vt.edu/web/toc.v/cid:kpAD000013/viewerType:toc//root_slug:aircraft-design/url_slug:aircraft-design)
+   `Publisher`
+
+9. **FND-TXT-S09** — [Introduction to Aircraft Design](https://doi.org/10.1017/9781139542418)
+   Fielding, J. P., *Introduction to Aircraft Design*, 2nd ed., Cambridge Aerospace Series,
+   Cambridge University Press, New York, NY, 2017. doi:10.1017/9781139542418
+   The shortest credible complete design text. Good first pass over the whole process when
+   the thousand-page books are too much, and strong on the airworthiness and operational
+   constraints that bound the design space.
+   `Publisher`
+
+10. **FND-TXT-S10** — The Elements of Aircraft Preliminary Design
+    Schaufele, R. D., *The Elements of Aircraft Preliminary Design*, Aries Publications,
+    Santa Ana, CA, 2000. ISBN 978-0-9701986-0-6.
+    Preliminary design as practised at Douglas, by the man who ran it there. Notable for
+    treating the airline customer as a design driver. No public copy located.
+    `Citation only`
+
+11. **FND-TXT-S11** — [Jet Sense: The Philosophy and the Art of Jet Transport Design](https://www.sae.org/books/jet-sense-philosophy-art-jet-transport-design-r-558)
+    Pastakia, Z. D., *Jet Sense: The Philosophy and the Art of Jet Transport Design*,
+    SAE International, Warrendale, PA, 2024. ISBN 978-1-4686-0599-0. Order no. R-558.
+    247 pp.
+    Commercial jet transport design specifically, argued from market requirement down to
+    geometry — wing design, landing gear integration, and initial sizing for single-aisle
+    and twin-aisle configurations, with collected data on existing jet transports. The
+    "philosophy and art" framing is the point: it is about the judgement behind the choice,
+    which is exactly what the equations in FND-TXT-P01 cannot give you.
+    `Publisher`
+
+---
+
+## Topic: Classic & Specialist Design Texts (CLS)
+
+Complete course-note sets, and older or narrower texts that remain the best source for
+something specific. Several are out of print; where a legal scan exists it is noted.
+
+### Primary References
+
+1. **FND-CLS-P01** — [Aircraft Design — Lecture Notes (HAW Hamburg)](https://www.fzt.haw-hamburg.de/pers/Scholz/FlugzeugentwurfE.html)
+   Scholz, D., *Aircraft Design*, Hamburg University of Applied Sciences (HAW Hamburg),
+   Aircraft Design and Systems Group (AERO).
+   Complete, freely available course notes covering the full preliminary design sequence —
+   the best open substitute for a textbook in this library. Consistently well-referenced
+   and unusually explicit about where each empirical relation comes from, which makes it the
+   right source to cite when you need to defend a number. Several chapters are cited
+   individually elsewhere, notably the empennage sections on
+   [Stability & Control]({{ site.baseurl }}/stability-control/).
+   `Open`
+
+### Secondary References
+
+1. **FND-CLS-S01** — [Subsonic Aircraft: Evolution and the Matching of Size to Performance](https://ntrs.nasa.gov/api/citations/19800020744/downloads/19800020744.pdf)
+   Loftin, L. K., Jr., *Subsonic Aircraft: Evolution and the Matching of Size to
+   Performance*, NASA RP-1060, NASA, Washington, DC, 1980.
+   NTRS citation: [19800020744](https://ntrs.nasa.gov/citations/19800020744)
+   The clearest published explanation of *why* the sizing constraints take the form they do,
+   built up through the history of the aircraft that established them. The matching-chart
+   development is the one to read before you build your own constraint diagram — and it is
+   free, unlike most of this topic.
+   `Open`
+
+2. **FND-CLS-S02** — [Lessons Learned: A Guide to Improved Aircraft Design](https://doi.org/10.2514/4.103827)
+   Nicolai, L. M., *Lessons Learned: A Guide to Improved Aircraft Design*, AIAA Library of
+   Flight, AIAA, Reston, VA, 2016. doi:10.2514/4.103827
+   Short, blunt chapters on design mistakes that reached hardware, each with what should
+   have been done instead. The most efficient way to acquire judgement you have not earned
+   yet. Read it early — the mistakes it describes are the ones student teams make.
+   VT access: [Knovel (VT sign-in)](https://app-knovel-com.ezproxy.lib.vt.edu/web/toc.v/cid:kpEGPDSB01/viewerType:toc//root_slug:lessons-learned-guide/url_slug:lessons-learned-guide)
+   `Publisher`
+
+3. **FND-CLS-S03** — [Aircraft Design Projects for Engineering Students](https://doi.org/10.2514/4.476198)
+   Jenkinson, L. R., and Marchman, J. F., *Aircraft Design Projects for Engineering
+   Students*, AIAA, Reston, VA, 2003. doi:10.2514/4.476198
+   Written for exactly this course, by a Virginia Tech professor and a design-course
+   colleague. Worked student-scale projects — advanced trainer, business jet, UAV — carried
+   from RFP to configuration. The most direct model available for what your report should
+   contain and how far the analysis should go.
+   VT access: [VT Libraries (VT sign-in)](https://virginiatech.primo.exlibrisgroup.com/permalink/01VT_INST/lirp1r/cdi_proquest_ebookcentral_EBC4952454)
+   `Publisher`
+
+4. **FND-CLS-S04** — [Supersonic and Subsonic Airplane Design](https://archive.org/details/supersonicsubson0000gera)
+   Corning, G., *Supersonic and Subsonic Airplane Design*, Braun-Brumfield, Ann Arbor, MI,
+   1964.
+   A 1960s design text from the era when supersonic transports were live projects. Still
+   worth opening for supersonic configuration layout and area ruling at conceptual level.
+   Borrowable scan at the Internet Archive with a free account.
+   `Publisher`
+
+5. **FND-CLS-S05** — [The Design of the Aeroplane](https://doi.org/10.2514/4.475146)
+   Stinton, D., *The Design of the Aeroplane*, 2nd ed., AIAA, Reston, VA, 2001.
+   doi:10.2514/4.475146 (1st ed., Van Nostrand Reinhold, 1983.)
+   Design explained physically rather than numerically — why a configuration takes the shape
+   it does. The best antidote to sizing an aircraft you cannot picture. Also borrowable at
+   the [Internet Archive](https://archive.org/details/designofaeroplan0000stin).
+   `Publisher`
+
+6. **FND-CLS-S06** — [Fundamentals of Aircraft and Airship Design, Vol. II — Airship Design and Case Studies](https://doi.org/10.2514/4.868986)
+   Carichner, G. E., and Nicolai, L. M., *Fundamentals of Aircraft and Airship Design,
+   Volume II: Airship Design and Case Studies*, AIAA Education Series, AIAA, Reston, VA,
+   2013. doi:10.2514/4.868986
+   Buoyant and hybrid vehicle design. Relevant only if your RFP is lighter-than-air — but if
+   it is, this is the reference. The case studies are worth reading regardless as examples of
+   design decisions defended in full.
+   VT access: [Knovel (VT sign-in)](https://app-knovel-com.ezproxy.lib.vt.edu/web/toc.v/cid:kpFAADVADF/viewerType:toc//root_slug:fundamentals-of-aircraft)
+   `Publisher`
+
+---
+
+## Topic: Engineering Design & Decision Making (GED)
+
+Design as a general engineering activity — the material behind module F1. Read one of
+these, not all of them.
+
+### Primary References
+
+1. **FND-GED-P01** — [Theoretical Foundations for Decision Making in Engineering Design](https://doi.org/10.17226/10566)
+   National Research Council, *Theoretical Foundations for Decision Making in Engineering
+   Design*, The National Academies Press, Washington, DC, 2001. doi:10.17226/10566
+   Why the decision methods used in design are hard to justify formally — including where
+   weighted-sum scoring of alternatives breaks down. Directly applicable: most student trade
+   studies use exactly the method this report criticises. Free PDF from NAP.
+   `Open`
+
+### Secondary References
+
+1. **FND-GED-S01** — [Introduction to Engineering: A Project-Based Experience in Engineering Methods](https://doi.org/10.2514/4.104596)
+   Post, M. L., Brandt, S. A., and Barlow, D. N., *Introduction to Engineering: A
+   Project-Based Experience in Engineering Methods*, AIAA Education Series, AIAA, Reston,
+   VA, 2017. doi:10.2514/4.104596
+   The freshman-level companion to FND-TXT-S01, structured around a team project. Useful
+   mainly as a refresher on the mechanics of running a design project.
+   `Publisher`
+
+2. **FND-GED-S02** — [Engineering Design: A Materials and Processing Approach](https://archive.org/details/engineeringdesig0000diet)
+   Dieter, G. E., *Engineering Design: A Materials and Processing Approach*, 3rd ed.,
+   McGraw-Hill, New York, NY, 1999.
+   The standard general design text. Its treatment of concept generation, decision matrices
+   and material selection is the source most engineering design courses draw on. Borrowable
+   scan at the Internet Archive.
+   `Publisher`
+
+3. **FND-GED-S03** — [The Mechanical Design Process](https://archive.org/details/mechanicaldesign0000ullm)
+   Ullman, D. G., *The Mechanical Design Process*, McGraw-Hill, New York, NY, 1991.
+   (6th ed. is current.)
+   Design as a documented, repeatable process, with the templates to run it. The most
+   procedural of the general texts — worth skimming when your team is arguing about how to
+   make a decision rather than what to decide. Borrowable scan at the Internet Archive.
+   `Publisher`
+
+4. **FND-GED-S04** — The Engineering Design Process
+   Ertas, A., and Jones, J. C., *The Engineering Design Process*, John Wiley & Sons, New
+   York, NY, 1993. ISBN 978-0-471-59680-6.
+   Another general design process text; covers the same ground as FND-GED-S02 and S03. No
+   public copy located.
+   `Citation only`
+
+5. **FND-GED-S05** — [The Design of Everyday Things](https://openlibrary.org/works/OL2632656W/)
+   Norman, D. A., *The Design of Everyday Things*, Basic Books, New York, NY, 1988
+   (revised ed., 2013).
+   Not an engineering text. It is on the list because it is the clearest statement of the
+   idea that a design which is used incorrectly was designed incorrectly — which is the
+   whole of human factors, and directly relevant to your cockpit and cabin decisions.
+   `Publisher`
+
+6. **FND-GED-S06** — Introduction to Engineering Design
+   Woodson, T. T., *Introduction to Engineering Design*, McGraw-Hill Book Company, New York,
+   NY, 1966.
+   Historical; the earliest text on the list. No public copy located.
+   `Citation only`
+
+---
+
+## Topic: Systems Thinking & Systems Engineering (SYS)
+
+The material behind modules F2 and F3. An aircraft is a system, and most of the mistakes
+that end programmes are interface mistakes.
+
+### Primary References
+
+1. **FND-SYS-P01** — [NASA Systems Engineering Handbook](https://www.nasa.gov/reference/systems-engineering-handbook/)
+   National Aeronautics and Space Administration, *NASA Systems Engineering Handbook*,
+   NASA SP-2016-6105 Rev. 2, NASA, Washington, DC, 2016 (orig. SP-2007-6105 Rev. 1, 2007).
+   The most usable systems engineering reference in the list, and free. The engine of it is
+   the 17 common technical processes and the product-breakdown/verification logic. Use its
+   requirement-writing rules on your own requirements — most student requirements fail them.
+   Also on [NTRS](https://ntrs.nasa.gov/citations/20170001761).
+   `Open`
+
+2. **FND-SYS-P02** — [Systems Engineering Fundamentals](https://ocw.mit.edu/courses/16-885j-aircraft-systems-engineering-fall-2005/resources/sefguide_01_01/)
+   Defense Acquisition University Press, *Systems Engineering Fundamentals*, Defense
+   Acquisition University, Fort Belvoir, VA, 2001.
+   The DoD counterpart to FND-SYS-P01 and about a third the length. Best short explanation
+   of the requirements-analysis → functional-allocation → design-synthesis loop and of the
+   review sequence (SRR, PDR, CDR) your project imitates. Hosted by MIT OpenCourseWare as a
+   reading for 16.885J.
+   `Open`
+
+### Secondary References
+
+1. **FND-SYS-S01** — [Systems Engineering: Using Systems Thinking to Design Better Aerospace Systems](https://doi.org/10.1002/9780470686652.eae536)
+   Burge, S. E., "Systems Engineering: Using Systems Thinking to Design Better Aerospace
+   Systems," in *Encyclopedia of Aerospace Engineering*, edited by R. Blockley and W. Shyy,
+   John Wiley & Sons, 2010. doi:10.1002/9780470686652.eae536
+   A single encyclopedia article covering the whole argument for systems thinking in
+   aerospace. The cheapest way to get the concept if you are not going to read a book.
+   `Publisher`
+
+2. **FND-SYS-S02** — [Systems Engineering Principles and Practice](https://doi.org/10.1002/0471723630)
+   Kossiakoff, A., and Sweet, W. N., *Systems Engineering Principles and Practice*,
+   John Wiley & Sons, Hoboken, NJ, 2003. doi:10.1002/0471723630
+   The standard graduate systems engineering text. Go here for the full development-phase
+   structure and the systems-engineering method applied across a programme lifecycle.
+   VT access: [Wiley Online Library (VT sign-in)](https://onlinelibrary-wiley-com.ezproxy.lib.vt.edu/doi/book/10.1002/0471723630)
+   `Publisher`
+
+3. **FND-SYS-S03** — [Systems Engineering: Fundamentals and Applications](https://link.springer.com/book/10.1007/978-3-030-13431-0)
+   Haberfellner, R., de Weck, O., Fricke, E., and Vössner, S., *Systems Engineering:
+   Fundamentals and Applications*, Birkhäuser/Springer, Cham, 2019.
+   doi:10.1007/978-3-030-13431-0
+   The most current of the three, and the strongest on systems architecting and on handling
+   complexity and uncertainty in early design.
+   `Publisher`
+
+---
+
+## Topic: Preliminary Design & Optimization (OPT)
+
+### Primary References
+
+1. **FND-OPT-P01** — [Contributions to Aircraft Preliminary Design and Optimization](https://www.fzt.haw-hamburg.de/pers/Scholz/OPerA/NITA_DISS_A-C_Preliminary_Design_and_Optimization_2013.pdf)
+   Niţă, M. F., *Contributions to Aircraft Preliminary Design and Optimization*,
+   Ph.D. dissertation, Hamburg University of Applied Sciences, published by
+   Verlag Dr. Hut, Munich, 2013.
+   A complete, self-contained preliminary sizing and optimization method (the OPerA
+   method), documented end to end with worked examples. Excellent model for how to
+   structure and defend a sizing methodology in your own report.
+   Persistent link: [purl.org/aero/NITA_DISS_2013](https://purl.org/aero/NITA_DISS_2013).
+   `Open`
+
+### Secondary References
+
+1. **FND-OPT-S01** — [Enhancing Aircraft Conceptual Design using Multidisciplinary Optimization](https://kth.diva-portal.org/smash/record.jsf?pid=diva2%3A9120)
+   Raymer, D. P., *Enhancing Aircraft Conceptual Design using Multidisciplinary
+   Optimization*, Doctoral thesis, Dept. of Aeronautics, Royal Institute of Technology
+   (KTH), Stockholm, Report 2002-2, May 2002.
+   Raymer's own doctoral work on wrapping an optimizer around the conceptual design method
+   of FND-TXT-P01 — which optimization schemes actually find better aircraft, and how much
+   better. Read it before you decide to bolt an optimizer onto your sizing code.
+   `Open`
+
+---
+
+## Topic: Design Process Course Material (PRC)
+
+### Secondary References
+
+1. **FND-PRC-S01** — [16.885J Aircraft Systems Engineering (MIT OpenCourseWare)](https://ocw.mit.edu/courses/16-885j-aircraft-systems-engineering-fall-2004/)
+   Murman, E., Hansman, R. J., Willcox, K., et al., *16.885J / ESD.35J Aircraft Systems
+   Engineering*, Massachusetts Institute of Technology, Fall 2004. MIT OpenCourseWare.
+   Full lecture set treating the aircraft as a system: cost, weight, performance, safety,
+   reliability, subsystems and lifecycle. Several individual lectures are cited on the
+   [Cost]({{ site.baseurl }}/cost/), [Subsystems]({{ site.baseurl }}/subsystems-avionics/)
+   and [Operations]({{ site.baseurl }}/operations-environment/) pages.
+   `Open`

--- a/references/index.md
+++ b/references/index.md
@@ -1,0 +1,118 @@
+---
+layout: default
+title: Start Here
+nav_order: 1
+description: "Curated reference library for the Air Vehicle Design course sequence."
+permalink: /
+---
+
+# AVD Reference Library
+
+A curated, publicly-linked reference library for the **Air Vehicle Design** course sequence.
+
+Every entry below points to a source you can reach yourself — a journal DOI, a government
+repository, a university course page, or a publisher listing. Nothing here requires a
+course login.
+
+---
+
+## How the library is organized
+
+References are arranged by **where they fall in the design process**, not by which folder
+they happened to live in. Work down the list as the semester progresses:
+
+| # | Page | What it covers |
+|---|------|----------------|
+| 2 | [Course Modules]({{ site.baseurl }}/course-modules/) | Prof. Raj's 22 module decks — the course spine, plus syllabi |
+| 3 | [Foundations & Design Process]({{ site.baseurl }}/foundations/) | Textbooks, full design methodologies, systems engineering |
+| 4 | [Requirements & Concept of Operations]({{ site.baseurl }}/requirements-conops/) | RFPs, mission definition, ConOps, design constraints |
+| 5 | [Aerodynamics]({{ site.baseurl }}/aerodynamics/) | Drag build-up, Oswald factor, transonic airfoils and wings |
+| 6 | [Configuration & Fuselage]({{ site.baseurl }}/configuration-fuselage/) | Cabin layout, fuselage geometry, configuration selection |
+| 7 | [Propulsion & Performance]({{ site.baseurl }}/propulsion-performance/) | Engine decks, thrust models, cycle analysis, performance |
+| 8 | [Stability & Control]({{ site.baseurl }}/stability-control/) | Empennage sizing, static/dynamic stability, OEI |
+| 9 | [Structures & Weights]({{ site.baseurl }}/structures-weights/) | Weight estimation, structural sizing, historical regressions |
+| 10 | [Cost & Value]({{ site.baseurl }}/cost/) | DAPCA, DOC models, life-cycle and software cost |
+| 11 | [Survivability & Stealth]({{ site.baseurl }}/survivability-stealth/) | RCS fundamentals, signature control, survivability |
+| 12 | [Subsystems & Avionics]({{ site.baseurl }}/subsystems-avionics/) | Avionics, systems integration, landing gear, certification |
+| 13 | [Operations, Market & Environment]({{ site.baseurl }}/operations-environment/) | Airline economics, cargo, air traffic, emissions |
+| 14 | [Electrified Aircraft]({{ site.baseurl }}/electrified-aircraft/) | Powertrain terminology and models |
+| 15 | [Mission Case Studies]({{ site.baseurl }}/case-studies/) | Worked designs by mission type |
+| 16 | [Project Management & Ethics]({{ site.baseurl }}/project-management-ethics/) | Running the project; professional responsibility |
+| 17 | [Industry News & Current Events]({{ site.baseurl }}/industry-news/) | Trade press, market and program commentary |
+
+{: .note }
+> Pages 2 and 16 are used from week one — the module set and the project-management
+> material are not background reading, they are how the semester is run.
+
+---
+
+## Reference ID scheme
+
+Every reference has a stable ID so it can be cited in assignments, reviews and design
+reports without ambiguity:
+
+```
+STC-EMP-P01
+ |   |   | |
+ |   |   | +-- sequence number
+ |   |   +---- P = Primary, S = Secondary
+ |   +-------- Topic code (EMP = Empennage)
+ +------------ Category code (STC = Stability & Control)
+```
+
+**Primary** references are the methods you are expected to actually use.
+**Secondary** references give background, worked examples, alternative methods, or data.
+
+If you are reading a slide deck that cites a reference by a different number — *AVD 2*,
+*AS 5*, *FM 1* — that is Prof. Raj's numbering from the original course bibliography. The
+[crosswalk]({{ site.baseurl }}/course-modules/#crosswalk-rajs-reference-numbers--this-library)
+on the Course Modules page maps every one of his 62 references to its entry here.
+
+### Category codes
+
+| Code | Category | Code | Category |
+|------|----------|------|----------|
+| `FND` | Foundations & Design Process | `CST` | Cost & Value |
+| `REQ` | Requirements & ConOps | `SUR` | Survivability & Stealth |
+| `AER` | Aerodynamics | `SUB` | Subsystems & Avionics |
+| `CFG` | Configuration & Fuselage | `OPS` | Operations, Market & Environment |
+| `PRP` | Propulsion & Performance | `ELA` | Electrified Aircraft |
+| `STC` | Stability & Control | `CAS` | Mission Case Studies |
+| `STW` | Structures & Weights | `NEW` | Industry News |
+| `MOD` | Course Modules | `PMG` | Project Management & Ethics |
+
+---
+
+## Availability tags
+
+Not everything worth citing is free. Each entry is tagged:
+
+| Tag | Meaning |
+|-----|---------|
+| `Open` | Free and directly downloadable at the link given. |
+| `Publisher` | Not freely downloadable. The link goes to the publisher, DOI landing page, or a borrowable Internet Archive scan. Check the [VT University Libraries](https://lib.vt.edu/) for institutional access. |
+| `Citation only` | No public copy located. The full citation is given so you can request it through [Interlibrary Loan](https://lib.vt.edu/find-borrow/interlibrary-loan.html) or buy it. |
+
+Many `Publisher` entries also carry a **VT access** link — the same book through a
+Virginia Tech University Libraries subscription (Knovel, Wiley Online Library,
+ScienceDirect, ProQuest Ebook Central). Those links resolve on the campus network, or off
+campus through the library proxy once you sign in with your VT credentials. They are free
+to you; they will not work for anyone outside VT, so cite the DOI or publisher link in
+your report, not the proxy URL.
+
+Where no VT access link is shown, it is still worth searching
+[VT University Libraries](https://lib.vt.edu/) — subscription holdings change, and these
+links were taken from a 2024 list.
+
+{: .warning }
+> Several entries are hosted on university course pages as scans of copyrighted textbooks.
+> Where that is the case, the underlying book is cited alongside the link. Treat those
+> links as convenience copies and cite the book, not the URL.
+
+---
+
+## Using these in your report
+
+Cite the **original source**, not this page. Each entry gives you the full citation
+you need. If you use a method from a reference, name it explicitly — e.g.
+*"tail volume coefficients per Scholz (STC-EMP-P01)"* — so reviewers can check your work.

--- a/references/industry-news.md
+++ b/references/industry-news.md
@@ -1,0 +1,93 @@
+---
+layout: default
+title: Industry News & Current Events
+nav_order: 17
+permalink: /industry-news/
+---
+
+# Industry News & Current Events
+{: .no_toc }
+
+Trade press and market commentary. Design does not happen in a vacuum — programme
+decisions, industrial structure and market conditions shape what gets built as much as the
+physics does.
+
+{: .note }
+> Most of this page is subscription content. Check
+> [VT University Libraries](https://lib.vt.edu/) for institutional access to
+> *Aviation Week & Space Technology* before paying for a personal subscription.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Industry Structure & Programmes (IND)
+
+### Secondary References
+
+1. **NEW-IND-S01** — [Daily Memo: Boeing's Breakup Is Not If, But How And When](https://aviationweek.com/air-transport/aircraft-propulsion/daily-memo-boeings-breakup-not-if-how-when)
+   Bruno, M., *Aviation Daily* / Aviation Week Network, 15 October 2024.
+   Analysis of Boeing's financial position and the case for structural breakup. Relevant to
+   a design course because industrial capacity, capital availability and programme risk
+   appetite determine which designs are actually pursued.
+   `Publisher`
+
+2. **NEW-IND-S02** — [Aviation Week & Space Technology, 9–22 March 2026](https://aviationweek.com/aviation-week-space-technology)
+   *Aviation Week & Space Technology*, Vol. 188, 9–22 March 2026. Informa. 69 pp.
+   Rotorcraft special report; NASA X-59 first flight coverage; Rolls-Royce narrowbody engine
+   bid. Source issue for CAS-SST-S02.
+   `Publisher`
+
+3. **NEW-IND-S03** — [State of Stealth](https://aviationweek.com/defense/aircraft-propulsion/state-stealth-part-7-future-survivability)
+   *Aviation Week & Space Technology* special topic series, 2017.
+   See [Survivability & Stealth]({{ site.baseurl }}/survivability-stealth/).
+   `Publisher`
+
+---
+
+## Topic: Configuration Commentary (CFG)
+
+### Secondary References
+
+1. **NEW-CFG-S01** — [YF-23 Designer Offers His Take On Boeing's F-47 NGAD Configuration](https://aviationweek.com/defense/aircraft-propulsion/yf-23-designer-offers-his-take-boeings-f-47-ngad-configuration)
+   Warwick, G., *Aviation Week & Space Technology*, 11 April 2025.
+   See [Mission Case Studies]({{ site.baseurl }}/case-studies/).
+   `Publisher`
+
+2. **NEW-CFG-S02** — [YF-23 Designer Weighs In On How Lockheed Martin Could Evolve The F-35](https://aviationweek.com/aerospace/aircraft-propulsion/yf-23-designer-weighs-how-lockheed-martin-could-evolve-f-35)
+   Warwick, G., *Aviation Week & Space Technology*, 7 August 2025.
+   See [Mission Case Studies]({{ site.baseurl }}/case-studies/).
+   `Publisher`
+
+---
+
+## Topic: Staying Current (CUR)
+
+### Primary References
+
+1. **NEW-CUR-P01** — [Aviation Week Network](https://aviationweek.com/)
+   Daily and weekly aerospace industry news and analysis.
+   `Publisher`
+
+2. **NEW-CUR-P02** — [Vertiflite (Vertical Flight Society)](https://vtol.org/store/vertiflite.cfm)
+   Bi-monthly magazine of the Vertical Flight Society. The best single source for eVTOL,
+   AAM and rotorcraft developments. Source of ELA-LEX-P01.
+   `Publisher`
+
+3. **NEW-CUR-P03** — [eVTOL News (Vertical Flight Society)](https://evtol.news/)
+   Free companion news site to NEW-CUR-P02, including the VFS Electric VTOL Directory —
+   1,100+ catalogued designs. The fastest way to find a comparable aircraft for an
+   eVTOL project.
+   `Open`
+
+4. **NEW-CUR-P04** — [NASA Technical Reports Server (NTRS)](https://ntrs.nasa.gov/)
+   Free full-text access to NASA technical reports, conference papers and contractor
+   reports. Several references in this library came from here — check NTRS before assuming
+   a paper is paywalled.
+   `Open`
+
+5. **NEW-CUR-P05** — [DTIC Technical Reports](https://discover.dtic.mil/)
+   Defense Technical Information Center. Public-release military technical reports,
+   including CAS-CSF-P01 and CAS-CSF-P02.
+   `Open`

--- a/references/operations-environment.md
+++ b/references/operations-environment.md
@@ -1,0 +1,112 @@
+---
+layout: default
+title: Operations, Market & Environment
+nav_order: 13
+permalink: /operations-environment/
+---
+
+# Operations, Market & Environment
+{: .no_toc }
+
+The operator's view, the market the aircraft has to sell into, and the environmental
+constraints that increasingly set requirements.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Airline & Operator Perspective (AIR)
+
+### Primary References
+
+1. **OPS-AIR-P01** — [An Airline Viewpoint](https://ocw.mit.edu/courses/16-885j-aircraft-systems-engineering-fall-2004/resources/l9/)
+   *An Airline Viewpoint*, Lecture 9, 16.885J Aircraft Systems Engineering, MIT, Fall 2004.
+   Presentation by United Airlines. MIT OpenCourseWare. 18 pp.
+   What the customer actually cares about, from the customer. Read before you decide that
+   your design's selling point is cruise Mach number.
+   `Open`
+
+### Secondary References
+
+1. **OPS-AIR-S01** — [Architecting and Designing Air Transportation Systems](https://ocw.mit.edu/courses/16-886-air-transportation-systems-architecting-spring-2004/resources/09architecting/)
+   Clarke, J.-P., Lecture 9, 16.886 Air Transportation Systems Architecting, MIT,
+   4 March 2004. MIT OpenCourseWare. 54 pp.
+   Also listed under [Requirements & ConOps]({{ site.baseurl }}/requirements-conops/).
+   `Open`
+
+---
+
+## Topic: Cargo Operations & Market (CGO)
+
+### Primary References
+
+1. **OPS-CGO-P01** — [Air Cargo Economics](https://ocw.mit.edu/courses/16-886-air-transportation-systems-architecting-spring-2004/resources/06cargo_econmics/)
+   Clarke, J.-P., *Air Cargo Economics*, Lecture 6, 16.886 Air Transportation Systems
+   Architecting, MIT, 24 February 2004. MIT OpenCourseWare. 26 pp.
+   How cargo operations make money, and therefore what a freighter has to be good at.
+   `Open`
+
+2. **OPS-CGO-P02** — [Military and Commercial Cargo Mission Needs](https://ocw.mit.edu/courses/16-886-air-transportation-systems-architecting-spring-2004/resources/07mitmiltry_ndco/)
+   Rawdon, B. K. (Boeing Phantom Works), *Military and Commercial Cargo Mission Needs*,
+   Lecture 7, 16.886, MIT, 26 February 2004. MIT OpenCourseWare. 35 pp.
+   Requirements definition for cargo aircraft from an industry configurator. A good model
+   of how mission needs get translated into vehicle attributes.
+   `Open`
+
+### Secondary References
+
+1. **OPS-CGO-S01** — [Commercial Market for Cargo Operations, Part I](https://ocw.mit.edu/courses/16-886-air-transportation-systems-architecting-spring-2004/resources/08_cargopration1/)
+   Haggerty, A. C., Lecture 8 (Part 1), 16.886 Air Transportation Systems Architecting,
+   MIT, 2 March 2004. MIT OpenCourseWare. 39 pp.
+   Market structure and the commercial cargo landscape.
+   `Open`
+
+2. **OPS-CGO-S02** — [Commercial Market for Cargo Operations, Part II](https://ocw.mit.edu/courses/16-886-air-transportation-systems-architecting-spring-2004/resources/08_cargopration2/)
+   Haggerty, A. C., Lecture 8 (Part 2), 16.886, MIT, 2004. MIT OpenCourseWare. 33 pp.
+   Integrator operations case study (UPS): network, timing and tracking requirements.
+   `Open`
+
+3. **OPS-CGO-S03** — [Commercial Market for Cargo Operations, Part III](https://ocw.mit.edu/courses/16-886-air-transportation-systems-architecting-spring-2004/resources/08_cargopration3/)
+   Haggerty, A. C., Lecture 8 (Part 3), 16.886, MIT, 2004. MIT OpenCourseWare. 18 pp.
+   Rotorcraft and specialized cargo delivery roles.
+   `Open`
+
+---
+
+## Topic: Airport & Airspace Operations (APT)
+
+### Secondary References
+
+1. **OPS-APT-S01** — [A method for automatic airport operation counts using crowd-sourced ADS-B data](https://doi.org/10.3846/aviation.2022.18025)
+   Fala, N., Falas, C., and Falas, A., "A method for automatic airport operation counts
+   using crowd-sourced ADS-B data," *Aviation*, Vol. 26, No. 4, 2022, pp. 209–216.
+   doi:10.3846/aviation.2022.18025
+   Uses OpenSky ADS-B data to count takeoffs and landings automatically, validated against
+   FAA ATADS at Tulsa International and Purdue University Airport. Relevant if your design
+   targets non-towered or regional operations and you need real utilization data rather
+   than an assumed number. **Open access.**
+   Direct PDF: [journals.vilniustech.lt](https://journals.vilniustech.lt/index.php/Aviation/article/download/18025/11442)
+   `Open`
+
+---
+
+## Topic: Emissions & Environment (ENV)
+
+### Primary References
+
+1. **OPS-ENV-P01** — [Aviation and the Environment](https://ocw.mit.edu/courses/16-885j-aircraft-systems-engineering-fall-2004/resources/envir_factors2_1/)
+   Waitz, I. A., *Aviation & the Environment* (Environmental Factors: Noise and Emissions),
+   16.885J Aircraft Systems Engineering, MIT, 2003–2004. MIT OpenCourseWare. 56 pp.
+   Noise and emissions as design constraints — certification metrics, the sources of each,
+   and the design levers available. Still the clearest single overview.
+   Part 2: [envir_factors2_2](https://ocw.mit.edu/courses/16-885j-aircraft-systems-engineering-fall-2004/resources/envir_factors2_2/)
+   `Open`
+
+### Secondary References
+
+1. **OPS-ENV-S01** — [Evaluating hybrid-electric aircraft viability: The Ampaire Eco Caravan cost analysis](https://doi.org/10.1016/j.trd.2025.104759)
+   Cusati, V., et al., *Transportation Research Part D*, Vol. 144, 2025, Art. 104759.
+   Quantifies the emissions reduction alongside the cost penalty. See
+   [Cost & Value]({{ site.baseurl }}/cost/) for the full entry.
+   `Open`

--- a/references/project-management-ethics.md
+++ b/references/project-management-ethics.md
@@ -1,0 +1,102 @@
+---
+layout: default
+title: Project Management & Ethics
+nav_order: 16
+permalink: /project-management-ethics/
+---
+
+# Project Management & Ethics
+{: .no_toc }
+
+Running the project, and the professional obligations that come with signing off on a
+design. The course is graded on both.
+
+The primary material here is Prof. Raj's
+[Group III module set]({{ site.baseurl }}/course-modules/) (P1–P7) and module F4,
+*Decision-Making with Ethics and Integrity*. The references below are the background those
+modules were built on.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Project Management (PRJ)
+
+### Secondary References
+
+1. **PMG-PRJ-S01** — [What Every Engineer Should Know About Project Management](https://archive.org/details/whateveryenginee0000rusk)
+   Ruskin, A. M., and Estes, W. E., *What Every Engineer Should Know About Project
+   Management*, 2nd ed., Marcel Dekker, New York, NY, 1995. ISBN 978-0-8247-9538-9.
+   Short and unromantic: scope, schedule, budget and the handful of controls that actually
+   keep an engineering project on them. Written for engineers who have just been made
+   responsible for a project — which is precisely your position in this course.
+   The linked Internet Archive copy is the 1982 first edition, borrowable with a free account.
+   `Publisher`
+
+2. **PMG-PRJ-S02** — [A Guide to the Project Management Body of Knowledge (PMBOK Guide)](https://www.pmi.org/standards/pmbok)
+   Project Management Institute, *A Guide to the Project Management Body of Knowledge
+   (PMBOK® Guide)*, 3rd ed., PMI, Newtown Square, PA, 2004. (7th ed. is current.)
+   The reference definition of the PM vocabulary — work breakdown structure, critical path,
+   earned value, stakeholder register. Use it to name things correctly in your project plan;
+   it is a standard, not a tutorial, so do not try to read it straight through.
+   `Publisher`
+
+3. **PMG-PRJ-S03** — [Risk Modeling, Assessment, and Management](https://doi.org/10.1002/9780470422489)
+   Haimes, Y. Y., *Risk Modeling, Assessment, and Management*, 3rd ed., John Wiley & Sons,
+   Hoboken, NJ, 2009. doi:10.1002/9780470422489
+   The rigorous treatment behind module P5. Most useful for the distinction between
+   likelihood-consequence scoring (what you will actually do in the project) and the
+   quantitative risk methods that scoring is a stand-in for. Read the early chapters and
+   the risk-filtering method; the rest is a research monograph.
+   VT access: [ProQuest Ebook Central (VT sign-in)](https://ebookcentral.proquest.com/lib/vt/detail.action?docID=4040554)
+   `Publisher`
+
+---
+
+## Topic: Ethics, Integrity & Professional Responsibility (ETH)
+
+### Primary References
+
+1. **PMG-ETH-P01** — [Roger Boisjoly and the Challenger Disaster: The Ethical Dimensions](https://doi.org/10.1007/BF00383335)
+   Boisjoly, R. P., Curtis, E. F., and Mellican, E., "Roger Boisjoly and the Challenger
+   Disaster: The Ethical Dimensions," *Journal of Business Ethics*, Vol. 8, No. 4, April
+   1989, pp. 217–230. doi:10.1007/BF00383335
+   The engineer who argued against the launch, written with him. The value for a design
+   course is not the moral of the story but the mechanism: how a technical objection gets
+   procedurally converted into an acceptable risk. Watch what happens to the burden of
+   proof when management asks the engineers to prove the launch is *unsafe* rather than
+   prove it is safe.
+   `Publisher`
+
+2. **PMG-ETH-P02** — [Truth, Lies, and O-Rings: Inside the Space Shuttle Challenger Disaster](https://openlibrary.org/books/OL22672053M/)
+   McDonald, A. J., with Hansen, J. R., *Truth, Lies, and O-Rings: Inside the Space Shuttle
+   Challenger Disaster*, University Press of Florida, Gainesville, FL, 2009.
+   ISBN 978-0-8130-3326-6.
+   The full first-hand account from the Thiokol director who refused to sign the launch
+   recommendation, including what happened to him afterwards. Long, but the chapters around
+   the launch decision are the ones module F4 draws on.
+   `Publisher`
+
+### Secondary References
+
+1. **PMG-ETH-S01** — Studies in Ethics, Safety, and Liability for Engineers
+   Hoover, K., Fowler, W. T., and Stearman, R. O., *Studies in Ethics, Safety, and
+   Liability for Engineers*, The University of Texas at Austin, ca. early 1990s.
+   Case-study collection used as discussion material in module F4. No public copy located.
+   `Citation only`
+
+2. **PMG-ETH-S02** — [Professionalism / The Ford Pinto Gas Tank Controversy](https://en.wikibooks.org/wiki/Professionalism/The_Ford_Pinto_Gas_Tank_Controversy)
+   *Professionalism*, Wikibooks.
+   The canonical cost-benefit-analysis-versus-safety case, with the actual numbers from the
+   Grush-Saunby memo. Useful as the counterpoint to any trade study where you have assigned
+   a dollar value to a safety margin.
+   `Open`
+
+3. **PMG-ETH-S03** — [Everything You Need to Know about the VW Diesel-Emissions Scandal](https://www.caranddriver.com/news/a15339250/everything-you-need-to-know-about-the-vw-diesel-emissions-scandal/)
+   Atiyeh, C., "Everything You Need to Know about the VW Diesel-Emissions Scandal,"
+   *Car and Driver*, 4 December 2019.
+   A modern case where the unethical act was an engineering design decision — a defeat
+   device written into control software by engineers who knew what it was for. Closer to
+   what you will be asked to do than the historical aerospace cases.
+   `Open`

--- a/references/propulsion-performance.md
+++ b/references/propulsion-performance.md
@@ -1,0 +1,130 @@
+---
+layout: default
+title: Propulsion & Performance
+nav_order: 7
+permalink: /propulsion-performance/
+---
+
+# Propulsion & Performance
+{: .no_toc }
+
+Engine selection data, thrust models you can actually curve-fit, and the performance
+calculations they feed.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Engine Data & Selection (ENG)
+
+### Primary References
+
+1. **PRP-ENG-P01** — The Engine Handbook, 2014 Edition
+   Directorate of Propulsion, Air Force Life Cycle Management Center (AFLCMC/LPZ),
+   *The Engine Handbook*, 2014 Edition, Revision 2.0, U.S. Air Force. 88 pp.
+   Reference data for the USAF turbine engine inventory — thrust class, application,
+   physical dimensions and program status by engine. The standard starting point when
+   choosing an existing production engine to meet an RFP constraint. No public copy
+   located; the [AFLCMC Propulsion Directorate](https://www.aflcmc.af.mil/WELCOME/Organizations/Propulsion-Directorate/)
+   is the originating office.
+   `Citation only`
+
+2. **PRP-ENG-P02** — Aircraft Engine Handbook, 1992
+   Naval Air Systems Command, *Aircraft Engine Handbook*, U.S. Navy, 1992. 244 pp.
+   Navy counterpart to PRP-ENG-P01, covering the naval engine inventory of the period.
+   Still useful for legacy engines that remain in service. No public copy located.
+   `Citation only`
+
+### Secondary References
+
+1. **PRP-ENG-S01** — [Thrust Data for Performance Calculations](https://onlinelibrary.wiley.com/doi/10.1002/9780470117859.app4)
+   Saarlas, M., "Appendix D: Thrust Data for Performance Calculations," in
+   *Aircraft Performance*, John Wiley & Sons, Hoboken, NJ, 2007.
+   ISBN 978-0-470-04416-2. doi:10.1002/9780470117859.app4
+   Engine decks for ten representative engines — J60, J52, JT9D-3, JT8D-9, TF30, TFE731-2,
+   GE F404-400, FJ44, Allison T56 turboprop and an AVCO Lycoming unit — presented as
+   curve-fits of thrust versus altitude and velocity. Exactly the form you need for a
+   performance code when you cannot get a real deck.
+   `Publisher`
+
+---
+
+## Topic: Thrust Modelling (THR)
+
+### Primary References
+
+1. **PRP-THR-P01** — [Measurement Effects on the Calculation of In-Flight Thrust for an F404 Turbofan Engine](https://ntrs.nasa.gov/api/citations/19900002425/downloads/19900002425.pdf)
+   Conners, T. R., *Measurement Effects on the Calculation of In-Flight Thrust for an F404
+   Turbofan Engine*, NASA TM-4140, NASA Dryden Flight Research Facility, 1989. 25 pp.
+   NTRS citation: [19900002425](https://ntrs.nasa.gov/citations/19900002425)
+   In-flight thrust calculation for the F404-GE-400 as flown on the X-29A, using the
+   mass flow–temperature and area–pressure gas generator methods. Includes net thrust
+   uncertainty and influence coefficients — read it for how much you should trust a thrust
+   number, not just how to compute one.
+   `Open`
+
+---
+
+## Topic: Aircraft Performance (PER)
+
+### Secondary References
+
+1. **PRP-PER-S01** — [Aircraft Performance](https://www.wiley.com/en-us/Aircraft+Performance-p-9780470044162)
+   Saarlas, M., *Aircraft Performance*, John Wiley & Sons, Hoboken, NJ, 2007.
+   ISBN 978-0-470-04416-2.
+   Parent text for PRP-ENG-S01. Standard treatment of the performance equations —
+   takeoff, climb, cruise, turn, and range/endurance — at the level a conceptual design
+   report needs.
+   `Publisher`
+
+2. **PRP-PER-S02** — [Advanced Aircraft Flight Performance](https://doi.org/10.1017/CBO9781139161893)
+   Filippone, A., *Advanced Aircraft Flight Performance*, Cambridge Aerospace Series,
+   Cambridge University Press, Cambridge, 2012. doi:10.1017/CBO9781139161893
+   Performance past the textbook equations: flight envelopes, mission analysis, fuel
+   planning, noise and emissions trajectories. Go here when a reviewer asks what your
+   aircraft does off the design point. Raj's list gives an AIAA imprint and 1996 date for
+   this title; the Cambridge edition above is the one that exists.
+   `Publisher`
+
+---
+
+## Topic: Propulsion Texts (TXT)
+
+*Aircraft Engine Design* (Mattingly, Heiser and Pratt) is a core text for this course and
+is listed on the Foundations page as
+[FND-TXT-P03]({{ site.baseurl }}/foundations/) — go there for engine constraint and
+mission analysis. The references below support it.
+
+### Primary References
+
+1. **PRP-TXT-P01** — [Elements of Propulsion: Gas Turbines and Rockets](https://doi.org/10.2514/4.103711)
+   Mattingly, J. D., *Elements of Propulsion: Gas Turbines and Rockets*, 2nd ed., AIAA
+   Education Series, AIAA, Reston, VA, 2016. doi:10.2514/4.103711
+   (1st ed., 2006, doi:[10.2514/4.861789](https://doi.org/10.2514/4.861789).)
+   Where the engine cycle comes from. For a conceptual design the payoff is parametric
+   cycle analysis: it tells you which of the numbers on an engine deck are physically
+   linked, so you know what you may and may not scale independently.
+   VT access: [Knovel (VT sign-in)](https://app-knovel-com.ezproxy.lib.vt.edu/web/view/khtml/show.v/rcid:kpEPGTR002/cid:kt0046LK6H/viewerType:khtml//root_slug:1-introduction/url_slug:introduction-2)
+   `Publisher`
+
+### Secondary References
+
+1. **PRP-TXT-S01** — [Aircraft Propulsion Systems Technology and Design](https://doi.org/10.2514/4.861499)
+   Oates, G. C. (ed.), *Aircraft Propulsion Systems Technology and Design*, AIAA Education
+   Series, AIAA, Washington, DC, 1989. doi:10.2514/4.861499
+   Edited volume on propulsion system *integration* — installation losses, inlet and nozzle
+   matching, and the design and development process for an engine programme. The chapter on
+   propulsion/airframe integration is the relevant one for a configuration study.
+   VT access: [Knovel (VT sign-in)](https://app-knovel-com.ezproxy.lib.vt.edu/web/toc.v/cid:kpAPSTD00K/viewerType:toc/root_slug:aircraft-propulsion-systems)
+   `Publisher`
+
+2. **PRP-TXT-S02** — [Intake Aerodynamics](https://doi.org/10.2514/4.473616)
+   Seddon, J., and Goldsmith, E. L., *Intake Aerodynamics*, 2nd ed., AIAA Education Series,
+   AIAA, Reston, VA / Blackwell Science, 1999. doi:10.2514/4.473616
+   The reference on inlet design and the pressure recovery your installed thrust depends on.
+   Necessary if your design is supersonic, has a buried or S-duct inlet, or puts the intake
+   anywhere the flow is not clean — all of which are configuration decisions you make on the
+   three-view.
+   VT access: [VT Libraries (VT sign-in)](https://virginiatech.primo.exlibrisgroup.com/permalink/01VT_INST/st7rnq/alma991001720169708646)
+   `Publisher`

--- a/references/requirements-conops.md
+++ b/references/requirements-conops.md
@@ -1,0 +1,92 @@
+---
+layout: default
+title: Requirements & Concept of Operations
+nav_order: 4
+permalink: /requirements-conops/
+---
+
+# Requirements & Concept of Operations
+{: .no_toc }
+
+Where a design starts: the request for proposal, the mission it has to fly, the
+environment it has to operate in, and the constraints that are non-negotiable.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Request for Proposal & Design Requirements (RFP)
+
+### Primary References
+
+1. **REQ-RFP-P01** — Design of a Next-Generation, Carrier-Based Strike Fighter Aircraft
+   Woodson, S. H., *Design of a Next-Generation, Carrier-Based Strike Fighter Aircraft*,
+   design requirements document prepared for the Virginia Tech undergraduate aircraft
+   design course, 2013. 6 pp.
+   Student-tailored RFP derived from open-source material, covering carrier suitability,
+   propulsion, materials, subsystem TRL and ordnance carriage constraints. Distributed
+   through the course; no public copy located.
+   `Citation only`
+
+2. **REQ-RFP-P02** — [AIAA Undergraduate Team Aircraft Design Competition](https://aiaa.org/awards/aircraft-design-competition/)
+   American Institute of Aeronautics and Astronautics, *Undergraduate Team Aircraft
+   Design Competition*, annual RFP.
+   The competition RFP is the cleanest available example of a real requirements document
+   written for a student team. Requirements change each year; read the current one even if
+   your project follows a different RFP.
+   `Open`
+
+### Secondary References
+
+1. **REQ-RFP-S01** — [Review of the Carrier Approach Criteria for Carrier-Based Aircraft, Phase I](https://apps.dtic.mil/sti/citations/ADA411068)
+   Rudowsky, T., Hynes, M., Luter, M., Niewoehner, R., Senn, P., et al., *Review of the
+   Carrier Approach Criteria for Carrier-Based Aircraft — Phase I: Final Report*,
+   NAWCADPAX/TR-2002/71, Naval Air Warfare Center Aircraft Division, Patuxent River, MD,
+   10 October 2002. 219 pp. DTIC accession ADA411068.
+   Where carrier approach speed requirements actually come from, and whether they are still
+   the right ones. Approved for public release. Direct PDF:
+   [apps.dtic.mil/sti/tr/pdf/ADA411068.pdf](https://apps.dtic.mil/sti/tr/pdf/ADA411068.pdf)
+   `Open`
+
+2. **REQ-RFP-S02** — [The Influence of Ship Configuration on the Design of the Joint Strike Fighter](https://apps.dtic.mil/sti/citations/ADA399988)
+   Ryberg, E. S., *The Influence of Ship Configuration on the Design of the Joint Strike
+   Fighter*, Engineering the Total Ship (ETS) 2002 Symposium, Gaithersburg, MD,
+   26–27 February 2002. Joint Strike Fighter Program Office. DTIC accession ADA399988.
+   A clean worked example of requirements flow-down from platform to aircraft: how deck
+   geometry, elevators, hangar height and catapults constrain the airframe. Direct PDF:
+   [apps.dtic.mil/sti/pdfs/ADA399988.pdf](https://apps.dtic.mil/sti/pdfs/ADA399988.pdf)
+   `Open`
+
+---
+
+## Topic: Concept of Operations (COO)
+
+### Primary References
+
+1. **REQ-COO-P01** — [Concept of Operations for Automated Flight Rules](https://cdn.bfldr.com/3FMO7QHS/as/3j55gvks8t92r5fv7jm2f5b/Wisk_Boeing_and_SkyGrid_ConOps)
+   Boeing, Wisk Aero, and SkyGrid, *Concept of Operations for Conduct of Flight under
+   Automated Flight Rules*, December 2025. 32 pp.
+   A current, industry-authored ConOps for a capability that does not yet exist. Read it as
+   a model of the document type: how a new operating concept is defined, bounded and
+   justified before any aircraft requirements are written.
+   Announcement: [wisk.aero newsroom](https://wisk.aero/newsroom/wisk-boeing-and-skygrid-release-concept-of-operations-for-automated-flight-rules)
+   `Open`
+
+2. **REQ-COO-P02** — [Enabling Scalable Urban Air Mobility Through Automated Flight Rules](https://www.skygrid.com/wp-content/uploads/2026/02/Enabling-Scalable-Urban-Air-Mobility-Through-Automated-Flight-Rules-White-Paper.pdf)
+   SkyGrid, LLC, and Wisk Aero, *Enabling Scalable Urban Air Mobility Through Automated
+   Flight Rules*, white paper, February 2026. 30 pp.
+   Narrows REQ-COO-P01 to low-altitude UAM operations. Useful pairing: the same authors
+   moving from a general framework to a specific application, which is exactly the move
+   you make from RFP to mission specification.
+   `Open`
+
+### Secondary References
+
+1. **REQ-COO-S01** — [Architecting and Designing Air Transportation Systems](https://ocw.mit.edu/courses/16-886-air-transportation-systems-architecting-spring-2004/resources/09architecting/)
+   Clarke, J.-P., *Architecting and Designing Air Transportation Systems*, Lecture 9,
+   16.886 Air Transportation Systems Architecting, MIT, 4 March 2004.
+   MIT OpenCourseWare.
+   Sets the aircraft inside the system it has to operate within — the step most student
+   designs skip. Read before fixing your mission profile.
+   `Open`

--- a/references/stability-control.md
+++ b/references/stability-control.md
@@ -1,0 +1,219 @@
+---
+layout: default
+title: Stability & Control
+nav_order: 8
+permalink: /stability-control/
+---
+
+# Stability & Control
+{: .no_toc }
+
+Empennage sizing, static and dynamic stability, lateral-directional characteristics, and
+the engine-out case.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Empennage Sizing (EMP)
+
+### Primary References
+
+1. **STC-EMP-P01** — [Empennage General Design](https://www.fzt.haw-hamburg.de/pers/Scholz/HOOU/AircraftDesign_9_EmpennageGeneralDesign.pdf)
+   Scholz, D., "Empennage General Design," Sec. 9 in *Aircraft Design*, Hamburg University
+   of Applied Sciences (HAW Hamburg). 16 pp.
+   Tail volume coefficient method to size horizontal and vertical tails. **Expected level
+   for the Fall semester.** Covers empennage types, functions, and the trim/stability/control
+   roles each surface plays.
+   `Open`
+
+2. **STC-EMP-P02** — [Empennage Sizing](https://www.fzt.haw-hamburg.de/pers/Scholz/HOOU/AircraftDesign_11_EmpennageSizing.pdf)
+   Scholz, D., "Empennage Sizing," Sec. 11 in *Aircraft Design*, Hamburg University of
+   Applied Sciences (HAW Hamburg). 29 pp.
+   In-depth empennage sizing from moment equilibrium, including full scissor-plot
+   development. **Expected level for the Spring semester.** Picks up exactly where
+   STC-EMP-P01 stops.
+   `Open`
+
+3. **STC-EMP-P03** — [Tail Design](http://aero.us.es/adesign/Slides/Extra/Stability/Design_Tail/Chapter%206.%20Tail%20Design.pdf)
+   Sadraey, M. H., "Tail Design," Ch. 6 in *Aircraft Design: A Systems Engineering
+   Approach*, John Wiley & Sons, 2012.
+   Step-by-step walkthrough of tail design with an explicit design procedure and worked
+   numbers. The most procedural of the three — useful when you want a checklist rather
+   than a derivation.
+   `Open`
+
+### Secondary References
+
+1. **STC-EMP-S01** — [Empennage Sizing and Aircraft Stability using Matlab](https://digitalcommons.calpoly.edu/aerosp/67/)
+   Struett, R. C., *Empennage Sizing and Aircraft Stability using Matlab*, Senior Project,
+   Aerospace Engineering Dept., California Polytechnic State University, San Luis Obispo,
+   June 2012. 37 pp.
+   Four-stage workflow: size the empennage for static stability, check dynamic stability
+   from the equations of motion, verify static stability across all flight conditions, then
+   augment. Includes the MATLAB source. A realistic model of scope for a student project.
+   Direct PDF: [digitalcommons.calpoly.edu](https://digitalcommons.calpoly.edu/cgi/viewcontent.cgi?article=1074&context=aerosp)
+   `Open`
+
+2. **STC-EMP-S02** — [Sizing and Optimization of the Horizontal Tail of a Jet Trainer](https://www.eucass.eu/doi/EUCASS2019-0335.pdf)
+   Karatoprak, S., and Özgen, S., "Sizing and Optimization of the Horizontal Tail of a Jet
+   Trainer," *8th European Conference for Aeronautics and Space Sciences (EUCASS)*, 2019.
+   doi:10.13009/EUCASS2019-335. 15 pp.
+   Horizontal tail sized to meet stability and control requirements across a specified CG
+   range, then optimized. Introduces relaxed static stability with active control and what
+   it buys in tail volume and weight. Good source of tail sizing diagrams.
+   `Open`
+
+3. **STC-EMP-S03** — [Aircraft Horizontal and Vertical Tail Design](https://aerotoolbox.com/design-aircraft-tail/)
+   AeroToolbox, "Aircraft Horizontal and Vertical Tail Design," *Fundamentals of Aircraft
+   Design* series.
+   Short, readable introduction to tail sizing with typical aspect ratios and configuration
+   trade-offs (conventional, T-tail, cruciform). Good orientation before tackling
+   STC-EMP-P01.
+   `Open`
+
+4. **STC-EMP-S04** — Tail Design and Sizing (Stanford AA241)
+   Kroo, I., and Shevell, R. S., "Tail Design and Sizing," in *Aircraft Design: Synthesis
+   and Analysis*, Desktop Aeronautics / Stanford University.
+   {: .warning }
+   > Both Stanford hosts (`adg.stanford.edu`, `aerodesign.stanford.edu`) are offline.
+   > Retained for the citation. Older captures exist — search
+   > `adg.stanford.edu/aircraftdesign/stability/taildesign.html` on the
+   > [Internet Archive Wayback Machine](https://web.archive.org/). The fuselage chapter of
+   > the same text is mirrored and linked as
+   > [CFG-FUS-P01]({{ site.baseurl }}/configuration-fuselage/).
+
+   `Citation only`
+
+---
+
+## Topic: Static & Dynamic Stability Analysis (SSA)
+
+### Primary References
+
+1. **STC-SSA-P01** — [Static Longitudinal Stability and Control (Perkins & Hage, Ch. 5–7)](http://wpage.unina.it/fabrnico/DIDATTICA/PGV_2012/MAT_DID_CORSO/03_Stab_Contr_Longitudinale/CAP5-7_PERKINS.pdf)
+   Perkins, C. D., and Hage, R. E., Chs. 5–7 in *Airplane Performance, Stability and
+   Control*, John Wiley & Sons, New York, 1949. ISBN 978-0-471-68046-8. 102 pp.
+   The classic longitudinal stability and control treatment. Still the clearest derivation
+   of neutral point, stick-fixed and stick-free stability, and elevator sizing for trim.
+   {: .warning }
+   > Scan of a copyrighted textbook hosted on the Università di Napoli Federico II course
+   > page. Cite the book, not the URL.
+   > [Publisher listing](https://www.wiley.com/en-ae/Airplane+Performance,+Stability+and+Control-p-9780471680468)
+
+   `Open`
+
+2. **STC-SSA-P02** — [Directional Stability and Control (Perkins & Hage)](http://wpage.unina.it/fabrnico/DIDATTICA/PGV_2012/MAT_DID_CORSO/04_Stab_Contr_Direzionale/Stab_Contr_DIR_Perkins.pdf)
+   Perkins, C. D., and Hage, R. E., "Directional Stability and Control," in *Airplane
+   Performance, Stability and Control*, John Wiley & Sons, 1949. 26 pp.
+   Weathercock stability, rudder sizing, and the asymmetric-thrust case. Read alongside
+   STC-OEI-P01.
+   {: .warning }
+   > Scan of a copyrighted textbook. Cite the book.
+
+   `Open`
+
+3. **STC-SSA-P03** — [Dihedral Effect and Lateral Control (Perkins & Hage)](http://wpage.unina.it/fabrnico/DIDATTICA/PGV_2012/MAT_DID_CORSO/05_EffDiedro_Contr_Rollio/EffDiedro_Rollio_Perkins.pdf)
+   Perkins, C. D., and Hage, R. E., "Dihedral Effect and Lateral Control," in *Airplane
+   Performance, Stability and Control*, John Wiley & Sons, 1949. 33 pp.
+   Where C<sub>lβ</sub> comes from, how wing position and sweep contribute, and how to size
+   ailerons for roll rate.
+   {: .warning }
+   > Scan of a copyrighted textbook. Cite the book.
+
+   `Open`
+
+### Secondary References
+
+1. **STC-SSA-S01** — [AeroFuse.jl Static Stability Analysis Tutorial](https://hkust-octad-lab.github.io/AeroFuse.jl/stable/tutorials-stability/#Static-Stability-Analysis)
+   HKUST OCTAD Lab, "Static Stability Analysis," *AeroFuse.jl* documentation.
+   Worked static stability analysis using a vortex lattice method (VLM) workflow. Useful if
+   you want to move past tail volume coefficients to a computed neutral point.
+   `Open`
+
+2. **STC-SSA-S02** — [Introduction to Aircraft Stability and Control (Course Notes, M&AE 5070)](https://courses.cit.cornell.edu/mae5070/Caughey_2011_04.pdf)
+   Caughey, D. A., *Introduction to Aircraft Stability and Control*, Course Notes for
+   M&AE 5070, Sibley School of Mechanical and Aerospace Engineering, Cornell University,
+   2011.
+   Full set of notes covering static longitudinal stability, the dynamical equations and
+   stability derivatives, and dynamic response to perturbations. The source of STC-DAT-P01.
+   `Open`
+
+---
+
+## Topic: Aircraft Data & Stability Derivatives (DAT)
+
+### Primary References
+
+1. **STC-DAT-P01** — [Stability Characteristics of the Boeing 747](https://courses.cit.cornell.edu/mae5070/B747_Data.pdf)
+   Caughey, D. A., "Stability Characteristics of the Boeing 747," Sec. 5.4 in
+   *Introduction to Aircraft Stability and Control*, Course Notes for M&AE 5070,
+   Cornell University, 2011.
+   Longitudinal, lateral and directional stability derivatives for the 747 at several
+   flight conditions (sea level, 20,000 ft, 40,000 ft; clean, and powered approach with
+   gear up and 20° flap), with the corresponding mass properties. The standard validation
+   dataset — check your own derivative estimates against these before trusting them.
+   `Open`
+
+---
+
+## Topic: One-Engine-Inoperative (OEI)
+
+### Primary References
+
+1. **STC-OEI-P01** — One-Engine-Inoperative (OEI) Analysis
+   Course lecture material, Air Vehicle Design, Virginia Tech.
+   V<sub>MC</sub> determination, rudder sizing for the engine-out case, and the
+   climb-gradient requirements that size the vertical tail on multi-engine designs.
+   Distributed through the course; no public copy located. For the underlying method see
+   STC-SSA-P02 and FAR/CS-25 Subpart B.
+   `Citation only`
+
+### Secondary References
+
+1. **STC-OEI-S01** — [14 CFR Part 25 Subpart B — Flight](https://www.ecfr.gov/current/title-14/chapter-I/subchapter-C/part-25/subpart-B)
+   U.S. Federal Aviation Administration, *Airworthiness Standards: Transport Category
+   Airplanes*, 14 CFR Part 25, Subpart B.
+   The binding source for V<sub>MC</sub>, V<sub>MCG</sub>, and the one-engine-inoperative
+   climb gradients (§25.111, §25.121, §25.149). If your design is transport category, size
+   the vertical tail against this, not against a rule of thumb.
+   `Open`
+
+---
+
+## Topic: Flight Mechanics Texts (TXT)
+
+### Primary References
+
+1. **STC-TXT-P01** — [Performance, Stability, Dynamics, and Control of Airplanes](https://doi.org/10.2514/4.102745)
+   Pamadi, B. N., *Performance, Stability, Dynamics, and Control of Airplanes*, 3rd ed.,
+   AIAA Education Series, AIAA, Reston, VA, 2015. doi:10.2514/4.102745
+   The single text covering everything on this page and the performance page in one
+   consistent notation — written by a Virginia Tech and NASA Langley author. Best feature
+   for a design course is that it derives the stability derivatives from geometry, so you
+   can compute them for *your* configuration rather than looking them up for someone else's.
+   VT access: [ProQuest Ebook Central (VT sign-in)](https://ebookcentral.proquest.com/lib/vt/detail.action?docID=3111614)
+   `Publisher`
+
+2. **STC-TXT-P02** — [Introduction to Aircraft Flight Mechanics](https://doi.org/10.2514/4.862069)
+   Yechout, T. R., with Morris, S. L., Bossert, D. E., and Hallgren, W. F., *Introduction to
+   Aircraft Flight Mechanics: Performance, Static Stability, Dynamic Stability, and
+   Classical Feedback Control*, AIAA Education Series, AIAA, Reston, VA, 2003.
+   doi:10.2514/4.862069 (3rd ed., 2024,
+   doi:[10.2514/4.107252](https://doi.org/10.2514/4.107252).)
+   The more approachable of the two. Comes out of the USAF Test Pilot School tradition, so
+   it stays tied to what the airplane actually does. The right first source for the dynamic
+   modes — phugoid, short period, Dutch roll, spiral — and for deciding whether yours need
+   augmentation.
+   `Publisher`
+
+### Secondary References
+
+1. **STC-TXT-S01** — Flying Qualities and Flight Testing of the Airplane
+   Stinton, D., *Flying Qualities and Flight Testing of the Airplane*, AIAA Education
+   Series, AIAA, Reston, VA, 1996. ISBN 978-1-56347-117-6.
+   Flying qualities from the pilot's side — what the handling-qualities requirements mean in
+   the cockpit, and how they get tested. Useful for justifying a Cooper-Harper-style claim
+   about your design rather than asserting it. No public copy located.
+   `Citation only`

--- a/references/structures-weights.md
+++ b/references/structures-weights.md
@@ -1,0 +1,103 @@
+---
+layout: default
+title: Structures & Weights
+nav_order: 9
+permalink: /structures-weights/
+---
+
+# Structures & Weights
+{: .no_toc }
+
+Weight estimation from historical data, and structural sizing when historical data is not
+good enough.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Weight Estimation from Historical Data (WHD)
+
+### Primary References
+
+1. **STW-WHD-P01** — [Predicting Conceptual Aircraft Design Parameters Using Gaussian Process Regressions on Historical Data](https://www.gokcincinar.com/publication/j-2026-joaircraft-gpr/j-2026-JoAircraft-GPR.pdf)
+   Arnson, M., Aljaber, R., and Cinar, G., "Predicting Conceptual Aircraft Design
+   Parameters Using Gaussian Process Regressions on Historical Data,"
+   *Journal of Aircraft*, 2026. doi:10.2514/1.C038387. 32 pp.
+   Replaces the classical single-variable weight regressions with Gaussian process
+   regressions over an open database of 400+ aircraft and 200+ engines. Non-parametric, so
+   inputs can be supplied in whatever combination you happen to have. Reports improved
+   accuracy on operating empty weight and uninstalled engine weight versus the standard
+   textbook relations.
+   The linked PDF is the authors' accepted manuscript (post-print); the published version
+   is at [doi.org/10.2514/1.C038387](https://doi.org/10.2514/1.C038387).
+   Landing page: [IDEAS Lab, University of Michigan](https://www.gokcincinar.com/publication/j-2026-joaircraft-gpr/)
+   `Open`
+
+### Secondary References
+
+1. **STW-WHD-S01** — [FAST — Future Aircraft Sizing Tool](https://github.com/ideas-um/FAST)
+   IDEAS Lab, University of Michigan, *FAST: Future Aircraft Sizing Tool*.
+   The open-source database and sizing tool behind STW-WHD-P01. The database alone is worth
+   having — it is the cleanest freely available source of consistent aircraft and engine
+   parameters for building your own regressions.
+   `Open`
+
+2. **STW-WHD-S02** — [Predicting Aircraft Design Parameters Using Gaussian Process Regressions on Historical Data](https://doi.org/10.2514/6.2025-1287)
+   Arnson, M., Aljaber, R., and Cinar, G., AIAA Paper 2025-1287, AIAA SciTech Forum, 2025.
+   The conference version of STW-WHD-P01. Shorter; useful if you want the method without
+   the full journal treatment.
+   `Publisher`
+
+---
+
+## Topic: Structural Design & Wing Weight (STR)
+
+### Primary References
+
+1. **STW-STR-P01** — [Enhanced Conceptual Wing Weight Estimation Through Structural Optimization and Simulation](https://labs.engineering.asu.edu/aircraft-design/wp-content/uploads/sites/115/2023/03/AIAA-2010-9075-Structural-Design-and-Weight-Estimation.pdf)
+   Petermeier, J., Radtke, G., Stohr, M., Woodland, A., Takahashi, T. T., Donovan, S., and
+   Shubert, M., "Enhanced Conceptual Wing Weight Estimation Through Structural Optimization
+   and Simulation," AIAA Paper 2010-9075, *13th AIAA/ISSMO Multidisciplinary Analysis
+   Optimization Conference*, Fort Worth, TX, 13–15 September 2010. 22 pp.
+   doi:10.2514/6.2010-9075
+   Builds a wing weight estimate from an actual optimized structure (Excel/VBA driving
+   CATIA and ABAQUS) rather than a historical regression, then compares against the
+   regressions. Read it to understand *when* the empirical weight equations stop being
+   trustworthy — unconventional planforms, unusual load paths, high aspect ratio.
+   Hosted by the [Takahashi Aircraft Design Lab, ASU](https://labs.engineering.asu.edu/aircraft-design/publications/).
+   `Open`
+
+### Secondary References
+
+1. **STW-STR-S01** — [Transport Category Wing Weight Estimation Using an Optimizing Beam-Element Structural Formulation](https://labs.engineering.asu.edu/aircraft-design/wp-content/uploads/sites/115/2023/05/AIAA-2015-1898.pdf)
+   Takahashi, T. T., et al., AIAA Paper 2015-1898, AIAA SciTech Forum, 2015.
+   doi:10.2514/6.2015-1898
+   The follow-on to STW-STR-P01 using a lighter-weight beam-element formulation — closer to
+   something you could actually implement inside a conceptual design loop.
+   `Open`
+
+---
+
+## Topic: Airframe Structures Texts (TXT)
+
+### Primary References
+
+1. **STW-TXT-P01** — Airframe Structural Design: Practical Design Information and Data on Aircraft Structures
+   Niu, M. C. Y., *Airframe Structural Design*, 2nd ed., Adaso/Adastra Engineering Center,
+   2011. ISBN 978-962-7128-09-0.
+   The practical airframe structures reference — how wing boxes, fuselage frames, cutouts,
+   joints and fittings are actually built and sized, with the data to do it. Use it to sanity
+   check that the structure implied by your weight estimate can physically exist. No public
+   copy located; the publisher sells direct.
+   `Citation only`
+
+### Secondary References
+
+1. **STW-TXT-S01** — Composite Airframe Structures: Practical Design Information and Data
+   Niu, M. C. Y., *Composite Airframe Structures*, 3rd ed., Hong Kong Conmilit Press,
+   Hong Kong, 2010. ISBN 978-962-7128-11-3.
+   The composites counterpart. Relevant the moment you claim a composite weight fraction —
+   it shows what the layup, joints and inspection provisions cost you, which is where naive
+   composite weight savings go. No public copy located.
+   `Citation only`

--- a/references/subsystems-avionics.md
+++ b/references/subsystems-avionics.md
@@ -1,0 +1,124 @@
+---
+layout: default
+title: Subsystems & Avionics
+nav_order: 12
+permalink: /subsystems-avionics/
+---
+
+# Subsystems & Avionics
+{: .no_toc }
+
+The systems that do not show up on the three-view but consume weight, power, volume and
+certification effort.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: Avionics & Air Data (AVI)
+
+### Primary References
+
+1. **SUB-AVI-P01** — Certification and Avionics
+   Hansman, R. J., *Certification and Avionics*, lecture, MIT International Center for Air
+   Transportation (ICAT) / 16.885J Aircraft Systems Engineering, MIT. 34 pp.
+   Avionics architecture and the certification path it drives — the reason avionics
+   selection is a schedule and cost decision, not just a weight and power one.
+   No public copy located; the parent course is
+   [16.885J on MIT OpenCourseWare](https://ocw.mit.edu/courses/16-885j-aircraft-systems-engineering-fall-2004/).
+   `Citation only`
+
+2. **SUB-AVI-P02** — Altimetry
+   Hansman, R. J., *Altimetry*, lecture, MIT International Center for Air Transportation
+   (ICAT) / 16.885J Aircraft Systems Engineering, MIT. 31 pp.
+   Pressure, density, barometric, MSL and AGL altitude and where each is used — pressure
+   altitude above the transition level, density altitude for performance. Worth being
+   precise about in your performance chapter.
+   No public copy located; parent course as above.
+   `Citation only`
+
+3. **SUB-AVI-P03** — [Civil Avionics Systems](https://doi.org/10.1002/9781118536704)
+   Moir, I., Seabridge, A., and Jukes, M., *Civil Avionics Systems*, 2nd ed., Aerospace
+   Series, John Wiley & Sons, Chichester, 2013. doi:10.1002/9781118536704
+   The reference for what is actually in a civil avionics suite: flight control and
+   management systems, navigation, displays, communications, data buses, and the integrated
+   modular avionics architecture that replaced federated boxes. Go here for realistic
+   avionics weight, power and cooling numbers instead of a percentage of empty weight.
+   VT access: [VT Libraries (VT sign-in)](https://virginiatech.primo.exlibrisgroup.com/permalink/01VT_INST/lirp1r/cdi_casalini_monographs_5773607)
+   `Publisher`
+
+### Secondary References
+
+1. **SUB-AVI-S01** — [16.885J Aircraft Systems Engineering — Lecture Notes](https://ocw.mit.edu/courses/16-885j-aircraft-systems-engineering-fall-2004/pages/lecture-notes/)
+   MIT OpenCourseWare, 16.885J / ESD.35J, Fall 2004.
+   The full publicly available lecture set, including flight controls, environmental
+   factors, cost, and an airline operator's perspective. The closest public substitute for
+   SUB-AVI-P01 and P02.
+   `Open`
+
+2. **SUB-AVI-S02** — [14 CFR Part 25 Subpart F — Equipment](https://www.ecfr.gov/current/title-14/chapter-I/subchapter-C/part-25/subpart-F)
+   U.S. Federal Aviation Administration, *Airworthiness Standards: Transport Category
+   Airplanes*, 14 CFR Part 25, Subpart F.
+   The required-equipment list, in binding form. Use it to justify what has to be in your
+   subsystem weight budget rather than guessing.
+   `Open`
+
+3. **SUB-AVI-S03** — [Military Avionics Systems](https://doi.org/10.1002/0470035463)
+   Moir, I., and Seabridge, A., *Military Avionics Systems*, Aerospace Series, John Wiley &
+   Sons / AIAA Education Series, 2006. doi:10.1002/0470035463
+   The military counterpart to SUB-AVI-P03: mission systems, sensors, stores management,
+   electronic warfare and the avionics implications of a survivability requirement. The one
+   to use if your RFP is a combat aircraft. See also
+   [Survivability & Stealth]({{ site.baseurl }}/survivability-stealth/).
+   VT access: [VT Libraries (VT sign-in)](https://virginiatech.primo.exlibrisgroup.com/permalink/01VT_INST/usm3rc/alma991013137664508646)
+   `Publisher`
+
+---
+
+## Topic: Aircraft Systems Integration (SYS)
+
+Power, actuation, environmental control, fuel and the rest of the systems that turn an
+airframe into an aircraft. Between them they are a large fraction of empty weight — assume
+a percentage at your peril.
+
+### Primary References
+
+1. **SUB-SYS-P01** — [Design and Development of Aircraft Systems](https://doi.org/10.1002/9781118469156)
+   Moir, I., and Seabridge, A., *Design and Development of Aircraft Systems*, 2nd ed.,
+   Aerospace Series, John Wiley & Sons, Chichester, 2012. doi:10.1002/9781118469156
+   (Also AIAA Education Series, doi:[10.2514/4.101809](https://doi.org/10.2514/4.101809).)
+   How systems get specified, integrated and certified across a development programme —
+   requirements capture, architecture selection, safety assessment, and the trade between
+   more-electric and conventional architectures. Read this one for *process*: it is the
+   systems-engineering module applied to the part of the aircraft you cannot draw.
+   VT access: [Wiley Online Library (VT sign-in)](https://onlinelibrary-wiley-com.ezproxy.lib.vt.edu/doi/book/10.1002/9781118469156)
+   `Publisher`
+
+2. **SUB-SYS-P02** — [Aircraft Systems: Mechanical, Electrical, and Avionics Subsystems Integration](https://doi.org/10.1002/9780470770931)
+   Moir, I., and Seabridge, A., *Aircraft Systems: Mechanical, Electrical, and Avionics
+   Subsystems Integration*, 3rd ed., Aerospace Series, John Wiley & Sons / AIAA Education
+   Series, 2008. doi:10.1002/9780470770931
+   Read this one for *content*: subsystem by subsystem — hydraulic, electrical, fuel,
+   environmental control, pneumatic, flight control actuation, ice protection, landing gear
+   — with architectures, sizing drivers and typical numbers. The reference to reach for when
+   your weight statement needs a systems line item you can defend.
+   VT access: [Wiley Online Library (VT sign-in)](https://onlinelibrary-wiley-com.ezproxy.lib.vt.edu/doi/book/10.1002/9780470770931)
+   `Publisher`
+
+---
+
+## Topic: Landing Gear (LDG)
+
+### Primary References
+
+1. **SUB-LDG-P01** — [Aircraft Landing Gear Design: Principles and Practices](https://doi.org/10.2514/4.861468)
+   Currey, N. S., *Aircraft Landing Gear Design: Principles and Practices*, AIAA Education
+   Series, AIAA, Washington, DC, 1988. doi:10.2514/4.861468
+   The standard landing gear reference, and the only one on this list that treats gear as a
+   configuration problem rather than a weight fraction. Covers tip-back and turnover
+   criteria, tire and wheel selection, shock absorber sizing, retraction kinematics and
+   stowage volume — all of which constrain the fuselage and wing layout you have already
+   drawn. Do the gear geometry early; it moves the wing.
+   VT access: [Knovel (VT sign-in)](https://app-knovel-com.ezproxy.lib.vt.edu/web/view/khtml/show.v/rcid:kpALGDPP06/cid:kt0046LBG2/viewerType:khtml//root_slug:title-page/url_slug:title-page)
+   `Publisher`

--- a/references/survivability-stealth.md
+++ b/references/survivability-stealth.md
@@ -1,0 +1,83 @@
+---
+layout: default
+title: Survivability & Stealth
+nav_order: 11
+permalink: /survivability-stealth/
+---
+
+# Survivability & Stealth
+{: .no_toc }
+
+Radar cross section and signature control, at the level that actually drives configuration
+layout.
+
+1. TOC
+{:toc}
+
+---
+
+## Topic: RCS for the Configuration Designer (RCS)
+
+### Primary References
+
+1. **SUR-RCS-P01** — [Fifteen Minutes of Stealth in Aircraft Design](https://pressbooks.lib.vt.edu/configurationaerodynamics/back-matter/appendix-b/)
+   Mason, W. H., "Appendix B: Fifteen Minutes of Stealth in Aircraft Design," in
+   *Lecture Notes on Configuration Aerodynamics*, Virginia Tech Open Textbook, University
+   Libraries, Virginia Tech. 9 pp.
+   **Read this first.** Exactly what a configuration designer needs and nothing more: how
+   monostatic RCS works, which shaping rules matter (no vertical surfaces from the side,
+   canted tails, chined fuselages, edge alignment), and where infrared, visual and aural
+   signature fit in. Written by someone who did this at Grumman.
+   `Open`
+
+### Secondary References
+
+1. **SUR-RCS-S01** — [Radar Cross Section, 2nd ed.](https://digital-library.theiet.org/doi/book/10.1049/sbra026e)
+   Knott, E. F., Shaeffer, J. F., and Tuley, M. T., *Radar Cross Section*, 2nd ed.,
+   SciTech Publishing / Artech House, 2004 (corrected reprint of the 1993 Artech House
+   edition). ISBN 1-891121-25-1. 627 pp.
+   The standard reference on RCS theory, prediction and reduction. Far beyond what a
+   conceptual design needs, but the place to go when SUR-RCS-P01 leaves you wanting the
+   derivation. IET Digital Library: doi:10.1049/sbra026e
+   `Publisher`
+
+2. **SUR-RCS-S02** — [Radar cross section fundamentals for the aircraft designer](https://doi.org/10.2514/6.1979-1818)
+   AIAA Paper 79-1818, *AIAA Aircraft Design and Technology Meeting*, 1979.
+   doi:10.2514/6.1979-1818
+   Older, but pitched deliberately at the aircraft designer rather than the electromagnetics
+   specialist. Good bridge between SUR-RCS-P01 and SUR-RCS-S01.
+   `Publisher`
+
+---
+
+## Topic: Signature Control & Survivability (SIG)
+
+### Primary References
+
+1. **SUR-SIG-P01** — Survivability (AE 4816 / AE 481 Lesson 13)
+   Canfield, R. A., "Survivability," Lesson 13, aircraft design course lecture material,
+   Kevin T. Crofton Dept. of Aerospace and Ocean Engineering, Virginia Tech.
+   Course treatment of susceptibility, vulnerability and the survivability trade against
+   performance and cost. Distributed through the course; no public copy located.
+   `Citation only`
+
+2. **SUR-SIG-P02** — Aircraft Signature Control Checklist
+   Design checklist covering radar, infrared, visual and acoustic signature control
+   measures. Course material; no public copy located.
+   `Citation only`
+
+### Secondary References
+
+1. **SUR-SIG-S01** — [State of Stealth](https://aviationweek.com/defense/aircraft-propulsion/state-stealth-part-7-future-survivability)
+   *State of Stealth*, special topic series, *Aviation Week & Space Technology*, 2017.
+   Seven-part survey of where stealth technology stood in 2017 and where survivability is
+   heading — counter-low-observable radar, infrared search and track, and the shift from
+   pure signature reduction toward broader survivability. Subscription required.
+   `Publisher`
+
+2. **SUR-SIG-S02** — [The Survivability of Aircraft (Ball)](https://arc.aiaa.org/doi/book/10.2514/4.862519)
+   Ball, R. E., *The Fundamentals of Aircraft Combat Survivability Analysis and Design*,
+   2nd ed., AIAA Education Series, 2003. doi:10.2514/4.862519
+   The standard text on combat survivability. Use for the susceptibility/vulnerability
+   framework if your RFP has an explicit survivability requirement.
+   `Publisher`


### PR DESCRIPTION
A curated, publicly-linked reference library for AOE 4065/4066, built as a just-the-docs Jekyll site.

It lives in references/ rather than docs/ so docs/ stays available for code documentation. GitHub Pages' deploy-from-a-branch mode can only serve / or /docs, so .github/workflows/pages.yml does the build instead and publishes on pushes to main that touch references/**. This needs Settings -> Pages -> Source set to "GitHub Actions".

190 entries across 17 pages, organised by design-process phase. Includes the Raj course modules, a crosswalk from his reference numbering, and VT library links alongside public DOIs.

baseurl is set to /air-vehicle-design; every internal link depends on it.